### PR TITLE
feat: hybrid semantic search (/recall-knowledge) — v1.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
-  "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, and /review-knowledge skills.",
-  "version": "1.10.2",
+  "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
+  "version": "1.11.0",
   "author": {
     "name": "LevNas"
   },

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .claude/
+
+# Python bytecode from scripts/ (kb_index.py / kb_search.py)
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.11.0] - 2026-06-16
+
+### Added
+- `/recall-knowledge` skill: on-demand **hybrid semantic search** over the knowledge base — lexical (ripgrep + mecab) fused with local vector embeddings and the `see:`-link graph (RRF), bridging synonyms and JA-query/EN-identifier gaps that keyword search misses (LevNas/notebooks#69)
+- `scripts/kb_index.py` — build/refresh a per-machine vector index (sha256 incremental, idempotent)
+- `scripts/kb_search.py` — hybrid query (lexical + vector + RRF + `see:` expansion + frontmatter filters) with lazy re-embed of changed entries
+- `hooks/post-merge.sample` — consumer-side incremental re-index after `git pull`
+- `docs/hybrid-search.md`, `docs/RUNBOOK-verify-hybrid-search.md` — setup, usage, and verification (incl. corporate TLS notes)
+
+### Requirements (optional — the feature is opt-in)
+- Semantic search needs `uv` (or Python ≥3.10) plus `fastembed` and `sqlite-vec`. The embedding model `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` (~220 MB) is downloaded **once** and runs fully local — no knowledge text leaves the machine.
+- **Graceful fallback**: without the index or these deps, `/recall-knowledge` falls back to ripgrep-only — nothing breaks.
+- The vector index (`.claude/knowledge/.index/kb.db`) is a per-machine derived cache and **must not be committed** (gitignore it; see `docs/hybrid-search.gitignore-snippet.txt`).
+
+### Notes
+- The per-prompt `userpromptsubmit_knowledge_search.sh` hook is **unchanged** (stays ripgrep — instant, no model load). Semantic search is on-demand only.
+- First-time setup / verification: follow `docs/RUNBOOK-verify-hybrid-search.md` — it covers dependency install, model download, index build, and corporate TLS inspection (`uv --system-certs` + `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`).
+
 ## [1.10.1] - 2026-04-10
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -109,6 +109,17 @@ rg '^title:' .claude/knowledge/entries/
 rg '^status: active' .claude/knowledge/entries/
 ```
 
+#### Semantic search (recall-knowledge, experimental)
+
+Beyond the keyword/filename lookups above, `/recall-knowledge` runs **hybrid semantic search** —
+ripgrep + local vector embeddings + the `see:`-link graph — so a query surfaces relevant entries
+even when worded differently (synonyms, or a Japanese query vs English identifiers). It runs
+on demand (the per-prompt hook stays ripgrep-only, instant and model-free) and falls back to
+ripgrep when the vector index or its dependencies are absent.
+
+- Setup & how it works: [docs/hybrid-search.md](docs/hybrid-search.md)
+- Verification / re-setup steps (incl. corporate TLS): [docs/RUNBOOK-verify-hybrid-search.md](docs/RUNBOOK-verify-hybrid-search.md)
+
 ### Reviewing Knowledge
 
 Periodically run `/review-knowledge` to maintain knowledge base health:

--- a/docs/RUNBOOK-verify-hybrid-search.md
+++ b/docs/RUNBOOK-verify-hybrid-search.md
@@ -1,0 +1,123 @@
+# Runbook: ハイブリッド検索 縦切りの検証（人が実シェルで実施）
+
+サブエージェントはサンドボックスでコード実行・ネットワーク・他repo書込が不可だったため、
+以下は**ネットワークのある実シェル**で人が実施する。スクリプトは ccmemo 作業ツリー内に
+**未コミットで配置済み**（`scripts/` 等）。そこから直接動かして**検証してから**コミット判断する。
+
+検証対象の的: `op-wrap` / `glab-op` を含むエントリ
+`notebooks/.claude/knowledge/entries/2026/06/20260610-134028-hasato-op-run-token-injection-wrappers.md`
+（本文は「トークン/認証」と書かれ「シークレット/credential」を**使っていない** → rg は同義語で取りこぼす）
+
+---
+
+## 変数（コピペ用）
+
+```bash
+KB=/home/hasato/src/github.com/LevNas/notebooks/.claude/knowledge/entries
+SCRIPTS=/home/hasato/src/github.com/LevNas/ccmemo/scripts
+```
+
+## 前提ツール確認
+
+```bash
+uv --version        # mise 管理で導入済みのはず
+mecab --version
+rg --version
+```
+
+無ければ: `uv` は mise（`mise install uv`）、`mecab` は OS パッケージ。
+
+---
+
+## Step 0. index を git に載せない保護（先にやる）
+
+notebooks は `.claude/` をコミット対象にしているため、派生インデックスが誤って
+commit されないよう **先に** ignore する。
+
+```bash
+cd /home/hasato/src/github.com/LevNas/notebooks
+grep -qxF '.claude/knowledge/.index/' .gitignore 2>/dev/null \
+  || echo '.claude/knowledge/.index/' >> .gitignore
+git check-ignore .claude/knowledge/.index/kb.db   # → パスが表示されれば無視OK
+```
+
+---
+
+## Step 1. 依存導入 + モデルDL + index ビルド（初回・ネットワーク必須）
+
+`uv run` は PEP 723 のインラインメタdata を読み、**(a) fastembed/sqlite-vec を一時環境に
+インストール**し、**(b) 初回はモデル ~100MB を取得**してから索引化する。3つが1コマンドで起きる。
+
+```bash
+uv run "$SCRIPTS/kb_index.py" "$KB"
+```
+
+- 期待出力例: `index: +142 ~0 -0 =0 (… chunks embedded) -> …/.claude/knowledge/.index/kb.db`
+- 初回は依存解決とモデルDLで時間がかかる。2回目以降は increment（変更分のみ）で高速
+- 生成物: `notebooks/.claude/knowledge/.index/kb.db`
+- 冪等: 変更なしで再実行すると `+0 ~0 -0`、何も embed しない
+
+### トラブル時
+- ネット遮断/プロキシ → モデルDL が失敗。社内 TLS インスペクション環境なら証明書設定が要る
+  （cf. ナレッジ `npm-self-signed-cert-windows-tls-inspection` と同系統の事象）
+- `uv` が無ければ `pip install 'fastembed>=0.3' 'sqlite-vec>=0.1.6'` 後に
+  `python3 "$SCRIPTS/kb_index.py" "$KB"`
+
+---
+
+## Step 2. rg ベースライン（取りこぼしを観測）
+
+同義語クエリで rg が的を外すことを確認する。
+
+```bash
+rg -l 'シークレット'  "$KB" | grep token-injection   # → 何も出ない（取りこぼし）
+rg -l 'credential'    "$KB" | grep token-injection   # → 何も出ない（取りこぼし）
+rg -l 'op-wrap'       "$KB"                            # → 1件（完全一致なら rg でも引ける）
+```
+
+期待: 同義語（シークレット / credential）では **的エントリが0件**。これが lexical 単独の限界。
+
+---
+
+## Step 3. hybrid 検索（同義語でも的が上位に来るか）
+
+```bash
+# rg が取りこぼした同義語で検索
+uv run "$SCRIPTS/kb_search.py" "$KB" "シークレット注入のラッパー" --top 8
+uv run "$SCRIPTS/kb_search.py" "$KB" "トークン注入のラッパー"   --top 8
+
+# フィルタ併用例
+uv run "$SCRIPTS/kb_search.py" "$KB" "認証情報の注入" --status active --tag '#secret-management' --top 8 --json
+```
+
+- 確認点: 出力上位に
+  `…2026/06/20260610-134028-hasato-op-run-token-injection-wrappers.md` が来ること
+- `--json` で機械可読出力。`--no-lazy`（検索前の自動再embed抑止）、`--no-mecab`（mecab前処理抑止）も可
+
+---
+
+## Step 4. 合否判定
+
+| 観点 | 合格基準 |
+| --- | --- |
+| 同義語リコール | rg が0件の「シークレット/credential」系クエリで、hybrid は的エントリを上位に出す |
+| 完全一致 | `op-wrap` 等の識別子そのままなら lexical アームで確実に拾う（劣化していない） |
+| 冪等性 | `kb_index.py` 再実行が `+0 ~0 -0` |
+| index 非コミット | `git check-ignore` でヒット、`git status` に `.index/` が出ない |
+
+- **合格** → 配置・配線・コミットの判断へ（下記）
+- **不合格/微妙** → チャンク粒度・RRF重み・mecab前処理をチューニング（メインブレインに戻して相談）
+
+---
+
+## 検証後（合格時のみ・別途判断）
+
+1. 配置済みファイル（`scripts/*.py`, `hooks/post-merge.sample`, `docs/*`）の最終構成を確定。
+   **要判断: docs を README 節にするか別ファイルのままか**
+2. consumer の `.gitignore` に `.claude/knowledge/.index/`（Step 0 で notebooks は対応済み）
+3. **要判断: consumer でのスクリプト設置場所**（post-merge フックの解決パス。現 install フローは
+   skills/templates のみコピーのため未定義）
+4. 既存 `userpromptsubmit_knowledge_search.sh` への配線
+5. コミットは英語メッセージ・ユーザー承認後（公開リポジトリ方針）
+
+> 注: 検証段階では ccmemo に何も置かず、コミットもしない。

--- a/docs/hybrid-search.gitignore-snippet.txt
+++ b/docs/hybrid-search.gitignore-snippet.txt
@@ -1,0 +1,3 @@
+# Consumer .gitignore snippet for ccmemo hybrid search.
+# The knowledge search index is a per-machine derived cache; never commit it.
+.claude/knowledge/.index/

--- a/docs/hybrid-search.md
+++ b/docs/hybrid-search.md
@@ -1,0 +1,108 @@
+# Hybrid Knowledge Search (experimental)
+
+A thin vertical slice that augments ccmemo's filename/`rg` knowledge lookup with a
+**local hybrid search**: lexical (ripgrep + mecab) fused with vector similarity
+(local embeddings), reinforced by the `see:` link graph.
+
+The Markdown knowledge base (`.claude/knowledge/entries/**/*.md` + frontmatter +
+`see:` links) is the source of truth. The search index is a **derived, per-machine
+cache** — regenerable at any time and **never committed to git**.
+
+## Scripts
+
+| Script | Purpose |
+| --- | --- |
+| `scripts/kb_index.py`  | Build / incrementally refresh the index from the Markdown |
+| `scripts/kb_search.py` | Query: lexical + vector arms, RRF fusion, `see:` 1-hop expansion, frontmatter filters |
+| `hooks/post-merge.sample` | Consumer git hook: incremental re-index after `git pull` |
+
+## Dependencies
+
+- [`fastembed`](https://pypi.org/project/fastembed/) — local ONNX embeddings.
+  Model: `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` (384-dim,
+  multilingual incl. Japanese). Downloads ~220 MB **once** into the fastembed
+  cache on first run. Nothing is sent to any external API — embedding is fully
+  local, satisfying the secret-management rule that knowledge body text must not
+  leave the machine.
+- [`sqlite-vec`](https://pypi.org/project/sqlite-vec/) — vector KNN inside SQLite.
+- `mecab`, `rg` — already required by the existing knowledge-search hook (the
+  lexical arm reuses the same Japanese tokenisation approach).
+
+### Running
+
+The scripts carry PEP 723 inline metadata, so the simplest path is
+[`uv`](https://docs.astral.sh/uv/) (already in this project's mise inventory):
+
+```bash
+# First run installs fastembed + sqlite-vec into an ephemeral env and downloads
+# the model (~100 MB, one time). Subsequent runs are fast.
+uv run scripts/kb_index.py  /path/to/.claude/knowledge/entries/
+uv run scripts/kb_search.py /path/to/.claude/knowledge/entries/ "クエリ"
+```
+
+Or install the two libs into any Python ≥3.10 environment and call `python3`
+directly:
+
+```bash
+pip install 'fastembed>=0.3' 'sqlite-vec>=0.1.6'
+python3 scripts/kb_index.py  /path/to/.claude/knowledge/entries/
+python3 scripts/kb_search.py /path/to/.claude/knowledge/entries/ "クエリ"
+```
+
+## Indexing
+
+```bash
+uv run scripts/kb_index.py ~/proj/.claude/knowledge/entries/
+# index: +142 ~0 -0 =0 (… chunks embedded) -> …/.claude/knowledge/.index/kb.db
+```
+
+- **Incremental & idempotent**: each entry's raw-text sha256 is stored; only
+  changed entries are re-embedded, deleted entries are purged. Re-running with no
+  changes embeds nothing.
+- **Chunking**: one chunk per entry, plus per-`##`-section chunks for large
+  entries (>1200 chars) so long entries stay retrievable section-by-section.
+- The DB lives at `<entries>/../.index/kb.db`, i.e.
+  `.claude/knowledge/.index/kb.db`.
+
+## Searching
+
+```bash
+uv run scripts/kb_search.py ~/proj/.claude/knowledge/entries/ "トークン注入のラッパー" \
+  --status active --tag '#secret-management' --top 8
+```
+
+Filters: `--status`, `--tag` (repeatable), `--type`, `--created-from`,
+`--created-to`. Other flags: `--top N`, `--json`, `--no-lazy`, `--no-mecab`.
+
+Pipeline: lexical rank (rg + mecab) and vector rank (sqlite-vec KNN) are each
+ranked, fused with **RRF (k=60)**, the top hits are **expanded one hop along
+`see:` links**, then frontmatter filters apply. Output is ranked `path` + score +
+snippet.
+
+**Lazy refresh**: before searching, on-disk hashes are compared with the index;
+changed/new entries are re-embedded just-in-time (disable with `--no-lazy`).
+
+## Index is not committed (consumer setup)
+
+The index is a per-machine derived cache. Committing the binary DB across machines
+or teammates would create unmergeable conflicts. Add to your project `.gitignore`:
+
+```gitignore
+.claude/knowledge/.index/
+```
+
+To keep it fresh after pulling teammates' new entries, install the post-merge
+hook:
+
+```bash
+cp path/to/ccmemo/hooks/post-merge.sample .git/hooks/post-merge
+chmod +x .git/hooks/post-merge
+# adjust CCMEMO_KB_ROOT / CCMEMO_KB_INDEX env vars if your layout differs
+```
+
+## Status
+
+Experimental vertical slice. It is **not wired into**
+`hooks/userpromptsubmit_knowledge_search.sh` yet — that hook still uses the
+existing rg-only lexical search. Wiring is deferred until this slice is validated
+against the rg baseline.

--- a/hooks/post-merge.sample
+++ b/hooks/post-merge.sample
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# ccmemo knowledge-index post-merge hook (SAMPLE — for consumers to install).
+#
+# After `git pull` / `git merge` updates the Markdown knowledge base, this runs an
+# *incremental* re-index so local hybrid search stays current. The index itself is
+# a per-machine derived cache and is NOT committed (see `.gitignore`:
+# `.claude/knowledge/.index/`). Only changed entries are re-embedded, so this is
+# cheap on a normal pull.
+#
+# Install (consumer side):
+#   cp path/to/ccmemo/hooks/post-merge.sample .git/hooks/post-merge
+#   chmod +x .git/hooks/post-merge
+#   # adjust KB_ROOT / KB_INDEX below if your layout differs
+#
+# It no-ops quietly when prerequisites (uv, the script, or the entries dir) are
+# missing, so it never blocks a merge.
+set -euo pipefail
+
+# Repo root (this hook lives in .git/hooks/).
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "${REPO_ROOT}" ] || exit 0
+
+KB_ROOT="${CCMEMO_KB_ROOT:-${REPO_ROOT}/.claude/knowledge/entries}"
+KB_INDEX="${CCMEMO_KB_INDEX:-${REPO_ROOT}/.claude/skills/.scripts/kb_index.py}"
+
+# Fallbacks for common install layouts (plugin vs. manual copy).
+if [ ! -f "${KB_INDEX}" ]; then
+  for cand in \
+    "${REPO_ROOT}/scripts/kb_index.py" \
+    "${REPO_ROOT}/.ccmemo/scripts/kb_index.py"; do
+    [ -f "${cand}" ] && KB_INDEX="${cand}" && break
+  done
+fi
+
+[ -d "${KB_ROOT}" ] || exit 0
+[ -f "${KB_INDEX}" ] || exit 0
+command -v uv >/dev/null 2>&1 || exit 0
+
+# Run in the background so the merge returns immediately; the model is already
+# cached after first use, and only changed entries are re-embedded.
+( uv run "${KB_INDEX}" "${KB_ROOT}" >/dev/null 2>&1 || true ) &
+
+exit 0

--- a/scripts/kb_index.py
+++ b/scripts/kb_index.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "fastembed>=0.3",
+#     "sqlite-vec>=0.1.6",
+# ]
+# ///
+"""Build / refresh a local hybrid-search index for a ccmemo knowledge base.
+
+The knowledge base (Markdown entries + YAML frontmatter + `- see:` links) is the
+source of truth. This index is a *derived* per-machine cache: it is regenerated
+from the Markdown at any time and MUST NOT be committed to git (see the .gitignore
+entry for `.claude/knowledge/.index/`).
+
+What it does
+------------
+- Scans every `*.md` under the knowledge root (recursively; dated subdirs OK).
+- Extracts frontmatter: title, tags, status, created, type.
+- Extracts `- see:` links from the body (relative paths to other entries).
+- Chunks the body: one chunk per entry, plus extra `##`-section chunks for large
+  entries (so long entries stay retrievable section-by-section).
+- Embeds each chunk locally with fastembed `paraphrase-multilingual-MiniLM-L12-v2` (384-dim).
+  Nothing is sent to any external API.
+- Upserts into a sqlite-vec DB at `<root>/../.index/kb.db`.
+- Incremental: stores a sha256 of each entry's raw text; only changed entries are
+  re-embedded, deleted entries are purged. Idempotent.
+
+Usage
+-----
+    # Preferred: self-contained run via uv (installs deps into an ephemeral env,
+    # downloads the ~100MB model once into the fastembed cache).
+    uv run scripts/kb_index.py /path/to/.claude/knowledge/entries/
+
+    # Or with deps already installed in the active interpreter:
+    python3 scripts/kb_index.py /path/to/.claude/knowledge/entries/
+
+Dependencies
+------------
+    fastembed   (local ONNX embeddings; pulls paraphrase-multilingual-MiniLM-L12-v2 on first run)
+    sqlite-vec  (vector KNN inside sqlite)
+
+The library functions here are imported by kb_search.py for lazy re-indexing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import struct
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+EMBED_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
+EMBED_DIM = 384
+# Entries longer than this many characters also get per-`##`-section chunks.
+LARGE_ENTRY_CHARS = 1200
+# sentence-transformers paraphrase-multilingual-MiniLM needs NO task prefix
+# (unlike e5, which wanted "passage:"/"query:"). Keep empty so embed_* stay generic.
+PASSAGE_PREFIX = ""
+QUERY_PREFIX = ""
+
+
+# --------------------------------------------------------------------------- #
+# Parsing
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class Entry:
+    path: Path           # absolute path
+    relpath: str         # path relative to the knowledge root (matches see: links)
+    title: str
+    tags: list[str]
+    status: str
+    created: str
+    type: str
+    see: list[str]       # relative paths referenced by `- see:` links
+    body: str            # body text (frontmatter stripped)
+    sha256: str
+    chunks: list[tuple[str, str]] = field(default_factory=list)  # (chunk_id, text)
+
+
+_SEE_LINK_RE = re.compile(r"^-\s+see:\s*\[[^\]]*\]\(([^)]+)\)", re.MULTILINE)
+_TAG_RE = re.compile(r"#[A-Za-z][A-Za-z0-9-]*")
+
+
+def _split_frontmatter(content: str) -> tuple[dict[str, str], str]:
+    """Return (frontmatter dict, body). Handles missing/blank frontmatter."""
+    if not content.startswith("---"):
+        return {}, content
+    end = content.find("\n---", 3)
+    if end == -1:
+        return {}, content
+    fm_block = content[3:end]
+    body = content[end + 4 :].lstrip("\n")
+    fm: dict[str, str] = {}
+    for line in fm_block.splitlines():
+        if ":" not in line:
+            continue
+        key, _, val = line.partition(":")
+        fm[key.strip()] = val.strip().strip('"').strip("'")
+    return fm, body
+
+
+def parse_entry(path: Path, root: Path) -> Entry | None:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    fm, body = _split_frontmatter(content)
+    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    tags = _TAG_RE.findall(fm.get("tags", ""))
+    see = [m.strip() for m in _SEE_LINK_RE.findall(body)]
+    try:
+        relpath = str(path.relative_to(root))
+    except ValueError:
+        relpath = path.name
+
+    entry = Entry(
+        path=path,
+        relpath=relpath,
+        title=fm.get("title", path.stem),
+        tags=tags,
+        status=fm.get("status", ""),
+        created=fm.get("created", ""),
+        type=fm.get("type", ""),
+        see=see,
+        body=body,
+        sha256=sha,
+    )
+    entry.chunks = _chunk_entry(entry)
+    return entry
+
+
+def _chunk_entry(entry: Entry) -> list[tuple[str, str]]:
+    """Whole-entry chunk + per-`##`-section chunks for large entries.
+
+    chunk_id is stable for a given entry+section so upserts are deterministic.
+    The title is prepended to every chunk to anchor the embedding.
+    """
+    chunks: list[tuple[str, str]] = []
+    title = entry.title.strip()
+    full = f"{title}\n\n{entry.body}".strip()
+    chunks.append(("full", full))
+
+    if len(entry.body) <= LARGE_ENTRY_CHARS:
+        return chunks
+
+    # Split on level-2 headings, keeping the heading with its section.
+    parts = re.split(r"(?m)^(##\s+.*)$", entry.body)
+    # parts = [pre, heading1, body1, heading2, body2, ...]
+    section_idx = 0
+    i = 1
+    while i < len(parts) - 1:
+        heading = parts[i].strip()
+        section_body = parts[i + 1].strip()
+        text = f"{title} — {heading.lstrip('# ').strip()}\n\n{section_body}".strip()
+        if section_body:
+            chunks.append((f"sec{section_idx}", text))
+            section_idx += 1
+        i += 2
+    return chunks
+
+
+def scan_entries(root: Path) -> dict[str, Entry]:
+    """Return {relpath: Entry} for every entry under root (CLAUDE.md excluded)."""
+    entries: dict[str, Entry] = {}
+    for path in sorted(root.rglob("*.md")):
+        if path.name == "CLAUDE.md":
+            continue
+        entry = parse_entry(path, root)
+        if entry is not None:
+            entries[entry.relpath] = entry
+    return entries
+
+
+# --------------------------------------------------------------------------- #
+# Database
+# --------------------------------------------------------------------------- #
+
+def index_db_path(root: Path) -> Path:
+    """`<root>/../.index/kb.db`. For .../knowledge/entries this is .../knowledge/.index/kb.db."""
+    return root.parent / ".index" / "kb.db"
+
+
+def connect(db_path: Path) -> sqlite3.Connection:
+    import sqlite_vec
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    return conn
+
+
+def init_schema(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS entries (
+            relpath  TEXT PRIMARY KEY,
+            title    TEXT,
+            tags     TEXT,   -- JSON list
+            status   TEXT,
+            created  TEXT,
+            type     TEXT,
+            see      TEXT,   -- JSON list of relpaths
+            sha256   TEXT
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS chunks (
+            rowid    INTEGER PRIMARY KEY AUTOINCREMENT,
+            relpath  TEXT,
+            chunk_id TEXT,
+            text     TEXT,
+            UNIQUE(relpath, chunk_id)
+        )
+        """
+    )
+    conn.execute(
+        f"""
+        CREATE VIRTUAL TABLE IF NOT EXISTS vec_chunks USING vec0(
+            chunk_rowid INTEGER PRIMARY KEY,
+            embedding FLOAT[{EMBED_DIM}]
+        )
+        """
+    )
+    conn.execute("CREATE TABLE IF NOT EXISTS meta (key TEXT PRIMARY KEY, value TEXT)")
+    conn.commit()
+
+
+def _stored_hashes(conn: sqlite3.Connection) -> dict[str, str]:
+    return {
+        row[0]: row[1]
+        for row in conn.execute("SELECT relpath, sha256 FROM entries")
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Embedding
+# --------------------------------------------------------------------------- #
+
+_EMBEDDER = None
+
+
+def get_embedder():
+    """Lazily construct the fastembed model (downloads ~220MB on first ever use)."""
+    global _EMBEDDER
+    if _EMBEDDER is None:
+        from fastembed import TextEmbedding
+
+        _EMBEDDER = TextEmbedding(model_name=EMBED_MODEL)
+    return _EMBEDDER
+
+
+def embed_passages(texts: list[str]) -> list[list[float]]:
+    model = get_embedder()
+    prefixed = [PASSAGE_PREFIX + t for t in texts]
+    return [vec.tolist() for vec in model.embed(prefixed)]
+
+
+def embed_query(text: str) -> list[float]:
+    model = get_embedder()
+    return next(iter(model.embed([QUERY_PREFIX + text]))).tolist()
+
+
+# --------------------------------------------------------------------------- #
+# Index maintenance
+# --------------------------------------------------------------------------- #
+
+def serialize_f32(vector: list[float]) -> bytes:
+    return struct.pack(f"{len(vector)}f", *vector)
+
+
+def _delete_entry_rows(conn: sqlite3.Connection, relpath: str) -> None:
+    rows = [
+        r[0]
+        for r in conn.execute(
+            "SELECT rowid FROM chunks WHERE relpath = ?", (relpath,)
+        )
+    ]
+    for rowid in rows:
+        conn.execute("DELETE FROM vec_chunks WHERE chunk_rowid = ?", (rowid,))
+    conn.execute("DELETE FROM chunks WHERE relpath = ?", (relpath,))
+    conn.execute("DELETE FROM entries WHERE relpath = ?", (relpath,))
+
+
+def _upsert_entry(conn: sqlite3.Connection, entry: Entry) -> int:
+    """(Re)write one entry and its chunks. Returns number of chunks embedded."""
+    _delete_entry_rows(conn, entry.relpath)
+    conn.execute(
+        "INSERT INTO entries (relpath, title, tags, status, created, type, see, sha256) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            entry.relpath,
+            entry.title,
+            json.dumps(entry.tags, ensure_ascii=False),
+            entry.status,
+            entry.created,
+            entry.type,
+            json.dumps(entry.see, ensure_ascii=False),
+            entry.sha256,
+        ),
+    )
+    texts = [text for _, text in entry.chunks]
+    if not texts:
+        return 0
+    vectors = embed_passages(texts)
+    for (chunk_id, text), vec in zip(entry.chunks, vectors):
+        cur = conn.execute(
+            "INSERT INTO chunks (relpath, chunk_id, text) VALUES (?, ?, ?)",
+            (entry.relpath, chunk_id, text),
+        )
+        rowid = cur.lastrowid
+        conn.execute(
+            "INSERT INTO vec_chunks (chunk_rowid, embedding) VALUES (?, ?)",
+            (rowid, serialize_f32(vec)),
+        )
+    return len(texts)
+
+
+def reindex(root: Path, *, only: set[str] | None = None, verbose: bool = True) -> dict:
+    """Incrementally refresh the index for `root`.
+
+    If `only` is given, restrict the scan/refresh to those relpaths (used by the
+    search-time lazy refresh). Returns a small stats dict.
+    """
+    db_path = index_db_path(root)
+    conn = connect(db_path)
+    init_schema(conn)
+
+    entries = scan_entries(root)
+    stored = _stored_hashes(conn)
+
+    if only is not None:
+        entries = {k: v for k, v in entries.items() if k in only}
+
+    added = changed = removed = unchanged = 0
+    embedded_chunks = 0
+
+    # Removals (skip when scoped to `only`, since we did not scan everything).
+    if only is None:
+        for relpath in list(stored):
+            if relpath not in entries:
+                _delete_entry_rows(conn, relpath)
+                removed += 1
+
+    for relpath, entry in entries.items():
+        prior = stored.get(relpath)
+        if prior == entry.sha256:
+            unchanged += 1
+            continue
+        embedded_chunks += _upsert_entry(conn, entry)
+        if prior is None:
+            added += 1
+        else:
+            changed += 1
+
+    conn.execute(
+        "INSERT INTO meta (key, value) VALUES ('last_indexed', ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (str(int(time.time())),),
+    )
+    conn.commit()
+    conn.close()
+
+    stats = {
+        "added": added,
+        "changed": changed,
+        "removed": removed,
+        "unchanged": unchanged,
+        "embedded_chunks": embedded_chunks,
+        "db": str(db_path),
+    }
+    if verbose:
+        print(
+            f"index: +{added} ~{changed} -{removed} ={unchanged} "
+            f"({embedded_chunks} chunks embedded) -> {db_path}"
+        )
+    return stats
+
+
+def detect_stale(root: Path) -> set[str]:
+    """Return relpaths whose on-disk sha256 differs from the index (or are new)."""
+    db_path = index_db_path(root)
+    if not db_path.exists():
+        # Whole base is stale.
+        return set(scan_entries(root).keys())
+    conn = connect(db_path)
+    init_schema(conn)
+    stored = _stored_hashes(conn)
+    conn.close()
+    stale: set[str] = set()
+    for path in root.rglob("*.md"):
+        if path.name == "CLAUDE.md":
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        rel = str(path.relative_to(root))
+        sha = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        if stored.get(rel) != sha:
+            stale.add(rel)
+    return stale
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def main(argv: list[str]) -> int:
+    if not argv:
+        print(__doc__)
+        print("error: knowledge root (entries dir) argument required", file=sys.stderr)
+        return 2
+    root = Path(argv[0]).expanduser().resolve()
+    if not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 2
+    reindex(root, verbose=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/kb_search.py
+++ b/scripts/kb_search.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "fastembed>=0.3",
+#     "sqlite-vec>=0.1.6",
+# ]
+# ///
+"""Hybrid search over a ccmemo knowledge base.
+
+Combines two retrieval arms and fuses them with Reciprocal Rank Fusion (RRF):
+
+  1. lexical arm  — ripgrep over the Markdown, optionally pre-tokenising the query
+                    with mecab (reusing the existing hook's approach) so Japanese
+                    queries split into searchable nouns.
+  2. vector arm   — KNN over locally-computed paraphrase-multilingual-MiniLM embeddings
+                    stored in the sqlite-vec index built by kb_index.py.
+
+After fusion, the top hits are expanded one hop along `see:` links (so a directly
+relevant entry pulls in its explicitly-linked neighbours), then frontmatter filters
+(status / tag / type / created range) are applied, and a ranked list of
+path + score + snippet is returned.
+
+Lazy refresh: before searching, on-disk sha256 hashes are compared with the index;
+any entry that changed (or is new) is re-embedded just-in-time so results never go
+stale. Disable with --no-lazy.
+
+Usage
+-----
+    uv run scripts/kb_search.py ROOT "クエリ" [filters...]
+    python3 scripts/kb_search.py ROOT "クエリ" [filters...]
+
+      ROOT                 knowledge entries dir (same arg as kb_index.py)
+      --status active      only entries with this status
+      --tag '#secret-management'   require this tag (repeatable)
+      --type knowledge     only this frontmatter type
+      --created-from 2026-05-01    created >= date (YYYY-MM-DD)
+      --created-to   2026-06-30    created <= date
+      --top N              number of results (default 8)
+      --no-lazy            skip search-time re-embedding of changed entries
+      --no-mecab           do not run mecab tokenisation for the lexical arm
+      --json               emit JSON instead of human-readable output
+
+Depends on kb_index.py (imported) plus the same fastembed / sqlite-vec deps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+# Import the sibling indexer module regardless of cwd.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import kb_index as kbi  # noqa: E402
+
+RRF_K = 60
+SNIPPET_CHARS = 160
+
+
+# --------------------------------------------------------------------------- #
+# Lexical arm (ripgrep, optional mecab tokenisation)
+# --------------------------------------------------------------------------- #
+
+def _mecab_keywords(query: str, min_len: int = 2) -> list[str]:
+    """Extract content nouns from a (Japanese) query, mirroring the existing hook."""
+    if not shutil.which("mecab"):
+        return []
+    try:
+        out = subprocess.run(
+            ["mecab"], input=query, capture_output=True, text=True, timeout=10
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return []
+    words: list[str] = []
+    for line in out.splitlines():
+        if line == "EOS" or "\t" not in line:
+            continue
+        surface, _, feat = line.partition("\t")
+        cols = feat.split(",")
+        if not cols:
+            continue
+        if cols[0] != "名詞":
+            continue
+        sub = cols[1] if len(cols) > 1 else ""
+        if sub in ("非自立", "代名詞", "数", "接尾"):
+            continue
+        if len(surface) >= min_len:
+            words.append(surface)
+    # Deduplicate, preserve order.
+    seen: set[str] = set()
+    uniq = []
+    for w in words:
+        if w not in seen:
+            seen.add(w)
+            uniq.append(w)
+    return uniq
+
+
+def _ascii_terms(query: str, min_len: int = 2) -> list[str]:
+    """ASCII word/identifier terms from the query (e.g. op-wrap, glab-op)."""
+    import re
+
+    terms = re.findall(r"[A-Za-z0-9][A-Za-z0-9_.-]*", query)
+    seen: set[str] = set()
+    out = []
+    for t in terms:
+        if len(t) >= min_len and t.lower() not in seen:
+            seen.add(t.lower())
+            out.append(t)
+    return out
+
+
+def lexical_rank(root: Path, query: str, use_mecab: bool) -> list[str]:
+    """Return entry relpaths ranked by lexical relevance (best first).
+
+    Scoring mirrors the existing hook: each matching term contributes 1/hit_count
+    to every file it matched, so rare terms weigh more. Terms matching too many
+    files are skipped as non-discriminating.
+    """
+    if not shutil.which("rg"):
+        return []
+
+    terms: list[str] = []
+    if use_mecab:
+        terms.extend(_mecab_keywords(query))
+    terms.extend(_ascii_terms(query))
+    # Fall back to whitespace splitting if tokenisers produced nothing.
+    if not terms:
+        terms = [t for t in query.split() if len(t) >= 2]
+    # Deduplicate case-insensitively.
+    seen: set[str] = set()
+    uniq_terms = []
+    for t in terms:
+        if t.lower() not in seen:
+            seen.add(t.lower())
+            uniq_terms.append(t)
+
+    hit_count_limit = 50
+    scores: dict[str, float] = {}
+    for term in uniq_terms:
+        try:
+            res = subprocess.run(
+                ["rg", "-l", "--fixed-strings", "--ignore-case", "--", term, str(root)],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        files = [ln for ln in res.stdout.splitlines() if ln.strip()]
+        n = len(files)
+        if n == 0 or n > hit_count_limit:
+            continue
+        for f in files:
+            p = Path(f)
+            if p.name == "CLAUDE.md":
+                continue
+            try:
+                rel = str(p.relative_to(root))
+            except ValueError:
+                continue
+            scores[rel] = scores.get(rel, 0.0) + 1.0 / n
+
+    return [rel for rel, _ in sorted(scores.items(), key=lambda kv: -kv[1])]
+
+
+# --------------------------------------------------------------------------- #
+# Vector arm (sqlite-vec KNN)
+# --------------------------------------------------------------------------- #
+
+def vector_rank(root: Path, query: str, k: int = 40) -> list[str]:
+    """Return entry relpaths ranked by best (closest) chunk distance, best first."""
+    db_path = kbi.index_db_path(root)
+    if not db_path.exists():
+        return []
+    qvec = kbi.embed_query(query)
+    conn = kbi.connect(db_path)
+    kbi.init_schema(conn)
+    rows = conn.execute(
+        """
+        SELECT c.relpath, v.distance
+        FROM vec_chunks v
+        JOIN chunks c ON c.rowid = v.chunk_rowid
+        WHERE v.embedding MATCH ? AND k = ?
+        ORDER BY v.distance
+        """,
+        (kbi.serialize_f32(qvec), k),
+    ).fetchall()
+    conn.close()
+    # Keep the best (smallest) distance per entry, preserve ascending order.
+    best: dict[str, float] = {}
+    for relpath, dist in rows:
+        if relpath not in best or dist < best[relpath]:
+            best[relpath] = dist
+    return [rel for rel, _ in sorted(best.items(), key=lambda kv: kv[1])]
+
+
+# --------------------------------------------------------------------------- #
+# Fusion + see: expansion + filters
+# --------------------------------------------------------------------------- #
+
+def rrf_fuse(*ranked_lists: list[str], k: int = RRF_K) -> dict[str, float]:
+    """Reciprocal Rank Fusion. Returns {relpath: fused_score}."""
+    fused: dict[str, float] = {}
+    for ranking in ranked_lists:
+        for rank, relpath in enumerate(ranking):
+            fused[relpath] = fused.get(relpath, 0.0) + 1.0 / (k + rank + 1)
+    return fused
+
+
+def expand_see_one_hop(root: Path, top: list[str], fused: dict[str, float]) -> None:
+    """Pull in entries directly linked from `top` (mutates `fused`).
+
+    A neighbour reachable from a top hit gets a small boost (half the linking
+    entry's score) so it can surface even if neither arm ranked it directly.
+    """
+    db_path = kbi.index_db_path(root)
+    if not db_path.exists():
+        return
+    conn = kbi.connect(db_path)
+    kbi.init_schema(conn)
+    known = {row[0] for row in conn.execute("SELECT relpath FROM entries")}
+    for relpath in top:
+        row = conn.execute(
+            "SELECT see FROM entries WHERE relpath = ?", (relpath,)
+        ).fetchone()
+        if not row or not row[0]:
+            continue
+        try:
+            neighbours = json.loads(row[0])
+        except json.JSONDecodeError:
+            continue
+        for nb in neighbours:
+            if nb in known and nb not in fused:
+                fused[nb] = 0.5 * fused.get(relpath, 0.0)
+    conn.close()
+
+
+def _entry_meta(root: Path) -> dict[str, dict]:
+    db_path = kbi.index_db_path(root)
+    meta: dict[str, dict] = {}
+    if not db_path.exists():
+        return meta
+    conn = kbi.connect(db_path)
+    kbi.init_schema(conn)
+    for relpath, title, tags, status, created, etype in conn.execute(
+        "SELECT relpath, title, tags, status, created, type FROM entries"
+    ):
+        meta[relpath] = {
+            "title": title,
+            "tags": json.loads(tags) if tags else [],
+            "status": status,
+            "created": created,
+            "type": etype,
+        }
+    conn.close()
+    return meta
+
+
+def apply_filters(meta: dict, *, status, tags, etype, created_from, created_to) -> bool:
+    if status and meta.get("status") != status:
+        return False
+    if etype and meta.get("type") != etype:
+        return False
+    if tags:
+        have = set(meta.get("tags", []))
+        if not set(tags).issubset(have):
+            return False
+    created = meta.get("created", "")
+    if created_from and (not created or created < created_from):
+        return False
+    if created_to and (not created or created > created_to):
+        return False
+    return True
+
+
+def make_snippet(path: Path, query: str) -> str:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+    _, body = kbi._split_frontmatter(content)
+    body = " ".join(body.split())
+    lowered = body.lower()
+    pos = -1
+    for term in _ascii_terms(query) + _mecab_keywords(query):
+        idx = lowered.find(term.lower())
+        if idx != -1:
+            pos = idx
+            break
+    if pos == -1:
+        return body[:SNIPPET_CHARS] + ("…" if len(body) > SNIPPET_CHARS else "")
+    start = max(0, pos - SNIPPET_CHARS // 3)
+    end = min(len(body), start + SNIPPET_CHARS)
+    prefix = "…" if start > 0 else ""
+    suffix = "…" if end < len(body) else ""
+    return prefix + body[start:end] + suffix
+
+
+# --------------------------------------------------------------------------- #
+# Driver
+# --------------------------------------------------------------------------- #
+
+def search(root: Path, query: str, *, top: int, use_mecab: bool, lazy: bool,
+           status, tags, etype, created_from, created_to) -> list[dict]:
+    if lazy:
+        stale = kbi.detect_stale(root)
+        if stale:
+            kbi.reindex(root, only=stale, verbose=False)
+
+    lex = lexical_rank(root, query, use_mecab)
+    vec = vector_rank(root, query)
+    fused = rrf_fuse(lex, vec)
+
+    # Expand see: from the current top before filtering.
+    pre_top = [r for r, _ in sorted(fused.items(), key=lambda kv: -kv[1])][: top * 2]
+    expand_see_one_hop(root, pre_top, fused)
+
+    meta = _entry_meta(root)
+    results = []
+    for relpath, score in sorted(fused.items(), key=lambda kv: -kv[1]):
+        m = meta.get(relpath, {})
+        if not apply_filters(
+            m, status=status, tags=tags, etype=etype,
+            created_from=created_from, created_to=created_to,
+        ):
+            continue
+        results.append(
+            {
+                "path": str(root / relpath),
+                "relpath": relpath,
+                "title": m.get("title", relpath),
+                "score": round(score, 5),
+                "status": m.get("status", ""),
+                "tags": m.get("tags", []),
+                "snippet": make_snippet(root / relpath, query),
+            }
+        )
+        if len(results) >= top:
+            break
+    return results
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Hybrid search over a ccmemo knowledge base.")
+    ap.add_argument("root", help="knowledge entries dir")
+    ap.add_argument("query", help="search query")
+    ap.add_argument("--status")
+    ap.add_argument("--tag", action="append", default=[], dest="tags")
+    ap.add_argument("--type", dest="etype")
+    ap.add_argument("--created-from")
+    ap.add_argument("--created-to")
+    ap.add_argument("--top", type=int, default=8)
+    ap.add_argument("--no-lazy", action="store_true")
+    ap.add_argument("--no-mecab", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args(argv)
+
+    root = Path(args.root).expanduser().resolve()
+    if not root.is_dir():
+        print(f"error: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    results = search(
+        root, args.query,
+        top=args.top,
+        use_mecab=not args.no_mecab,
+        lazy=not args.no_lazy,
+        status=args.status,
+        tags=args.tags,
+        etype=args.etype,
+        created_from=args.created_from,
+        created_to=args.created_to,
+    )
+
+    if args.json:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+    else:
+        if not results:
+            print("(no hits)")
+        for i, r in enumerate(results, 1):
+            print(f"{i}. [{r['score']}] {r['title']}")
+            print(f"   {r['relpath']}  ({r['status']}) {' '.join(r['tags'][:6])}")
+            if r["snippet"]:
+                print(f"   {r['snippet']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/skills/recall-knowledge/SKILL.md
+++ b/skills/recall-knowledge/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: recall-knowledge
+description: >-
+  Recall knowledge base entries by meaning, not just keywords — hybrid search (lexical ripgrep +
+  local vector embeddings + see-link graph) over `.claude/knowledge/entries/`. Use when looking for
+  prior knowledge, decisions, pitfalls, or context that may be worded differently from the query
+  (e.g. a Japanese query vs English identifiers, or synonyms the entry does not literally contain).
+  Falls back to ripgrep-only when the vector index or its dependencies are absent. On-demand only —
+  it is NOT wired into the per-prompt hook (that stays ripgrep for instant, model-free injection).
+license: MIT
+allowed-tools: Bash, Read
+---
+
+# Recall Knowledge
+
+## Goal
+Surface the most relevant knowledge entries for a query by meaning — bridging synonyms and
+cross-language wording (e.g. Japanese ↔ English identifiers) that literal keyword search misses.
+
+## When to Use
+- Searching the knowledge base for prior art, decisions, pitfalls, or related context
+- The query may be worded differently than the entries (synonyms, JA query vs EN identifiers)
+- Before starting work on a topic, to pull related accumulated knowledge
+- NOT for per-prompt automatic injection — that stays ripgrep via the existing
+  `userpromptsubmit_knowledge_search.sh` hook (instant, no model load)
+
+## Execution (run directly — do NOT delegate to a subagent)
+
+IMPORTANT: hybrid search executes code (`uv run` a Python script). Subagents run in a sandbox
+that blocks code execution, networking, and out-of-cwd writes, so this skill runs from the
+MAIN agent's Bash — do NOT spawn an Agent for the search itself.
+
+1. Read the procedure file at: {plugin_root}/skills/recall-knowledge/procedure.md
+2. Follow it: resolve paths, decide hybrid vs ripgrep-fallback, run the search, present the
+   ranked results, and Read the top entries when their content is needed for the answer.
+
+Paths:
+- Knowledge base: {project_root}/.claude/knowledge/
+- Search script:  {plugin_root}/scripts/kb_search.py
+- Index builder:  {plugin_root}/scripts/kb_index.py (only to advise building the index)
+
+IMPORTANT: The procedure / script paths use the plugin's base directory, NOT the project
+directory. Read the "Base directory for this skill" line from the skill loading message to
+determine `{plugin_root}`.

--- a/skills/recall-knowledge/procedure.md
+++ b/skills/recall-knowledge/procedure.md
@@ -1,0 +1,56 @@
+# Recall Knowledge — Procedure
+
+Hybrid semantic search over the knowledge base. Runs from the **main agent** (it executes code;
+subagents are sandboxed and cannot run `uv` / Python). On-demand only.
+
+## Inputs
+- `query` — the search text (required)
+- Optional filters: `status`, `tag` (repeatable), `type`, `created-from`, `created-to`, `top` (N)
+
+## Step 1. Resolve paths
+- `KB_ROOT` = `{project_root}/.claude/knowledge/entries`
+- `SEARCH`  = `{plugin_root}/scripts/kb_search.py`
+- `INDEX`   = `{project_root}/.claude/knowledge/.index/kb.db`
+- `BUILDER` = `{plugin_root}/scripts/kb_index.py` (referenced only when advising a build)
+
+## Step 2. Decide hybrid vs fallback
+Hybrid is available **iff** `uv` is on `PATH` **and** `INDEX` exists.
+- Both present → Step 3a (hybrid).
+- Otherwise → Step 3b (ripgrep fallback).
+
+## Step 3a. Hybrid search (preferred)
+Run from Bash (main agent):
+
+```bash
+uv run "{plugin_root}/scripts/kb_search.py" "{KB_ROOT}" "<query>" --top 8 \
+  [--status active] [--tag '#sometag'] [--type knowledge] \
+  [--created-from YYYY-MM-DD] [--created-to YYYY-MM-DD] [--json]
+```
+
+Notes:
+- **No network at search time**: the query is embedded with the locally cached model.
+- kb_search.py **lazily re-embeds changed entries** before searching, so results stay fresh
+  without a manual rebuild.
+- First-ever run after install (deps not yet cached) makes `uv` fetch fastembed/sqlite-vec.
+  Under corporate TLS inspection, add `--system-certs` and export
+  `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE` (see `{plugin_root}/docs/hybrid-search.md`). Normally
+  the index build already primed the cache, so plain `uv run` works.
+- A `UserWarning` about "mean pooling" is benign — ignore it.
+
+## Step 3b. Fallback — ripgrep only (no index / no deps)
+- Tokenise the query with `mecab` if present (mirroring the existing
+  `userpromptsubmit_knowledge_search.sh` approach), else split on whitespace; then
+  `rg -l <term> "{KB_ROOT}"` for each term and union the hits. For ASCII identifiers, `rg`
+  the literal token.
+- Tell the user semantic recall is **disabled**, and how to enable it:
+  ```bash
+  uv run "{plugin_root}/scripts/kb_index.py" "{KB_ROOT}"
+  ```
+  (first run downloads ~220 MB model; under corporate TLS see `docs/hybrid-search.md`)
+
+## Step 4. Present results
+- Show the ranked entries as printed by kb_search.py: score, title, relpath, tags, snippet.
+- For the top 1–2 hits, **Read** the entry file when its content is needed to answer.
+- Prefer `status: active`; if a top hit is `superseded`/`deprecated`, note it and prefer its
+  replacement (follow `superseded_by` / `see:` links).
+- Keep output concise — return the ranked list and the synthesized answer, not raw tool noise.


### PR DESCRIPTION
## Summary

Adds `/recall-knowledge` — on-demand **hybrid semantic search** over the knowledge base: lexical (ripgrep + mecab) fused with local vector embeddings and the `see:`-link graph via RRF. Bridges synonym and cross-language (JA query ↔ EN identifier) gaps that keyword search misses.

## What's included
- `skills/recall-knowledge/` — on-demand skill; runs from the main agent (vector search needs code execution, which sandboxed subagents cannot do); falls back to ripgrep when the index/deps are absent
- `scripts/kb_index.py` — per-machine vector index (sha256 incremental, idempotent)
- `scripts/kb_search.py` — lexical + vector + RRF + `see:` expansion + frontmatter filters, with lazy re-embed of changed entries
- `hooks/post-merge.sample` — consumer-side incremental re-index after `git pull`
- `docs/hybrid-search.md`, `docs/RUNBOOK-verify-hybrid-search.md`
- CHANGELOG v1.11.0; `plugin.json` bumped to 1.11.0

## Design notes
- **Opt-in & graceful**: needs `uv` / `fastembed` / `sqlite-vec`; the model (`sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2`, ~220 MB) is downloaded once and runs fully local (no knowledge text leaves the machine). Without the deps or index, `/recall-knowledge` falls back to ripgrep — nothing breaks.
- The per-prompt `userpromptsubmit_knowledge_search.sh` hook is **unchanged** (stays ripgrep — instant, no model load).
- The vector index (`.claude/knowledge/.index/kb.db`) is a per-machine derived cache and is git-ignored (never committed) to avoid cross-machine binary conflicts.

## Validation
- Indexed 143 entries / 947 chunks. A synonym query (`シークレット注入のラッパー`) surfaced the target `op-wrap` / `glab-op` entry at rank 2, where ripgrep returns nothing for that synonym. Idempotent re-index and ripgrep-fallback confirmed.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

