### PR TITLE
docs: README overhaul + recall-knowledge surfacing + CHANGELOG 1.10.2 backfill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ All notable changes to this project will be documented in this file.
 - The per-prompt `userpromptsubmit_knowledge_search.sh` hook is **unchanged** (stays ripgrep — instant, no model load). Semantic search is on-demand only.
 - First-time setup / verification: follow `docs/RUNBOOK-verify-hybrid-search.md` — it covers dependency install, model download, index build, and corporate TLS inspection (`uv --system-certs` + `SSL_CERT_FILE` / `REQUESTS_CA_BUNDLE`).
 
+## [1.10.2] - 2026-04-16
+
+### Fixed
+- Remove Sonnet model pinning from the record-knowledge subagent so it inherits the active session model instead of forcing a fixed model
+
 ## [1.10.1] - 2026-04-10
 
 ### Removed
@@ -113,6 +118,10 @@ All notable changes to this project will be documented in this file.
 - Plugin marketplace support via plugin.json
 - MIT License
 
+[1.11.0]: https://github.com/LevNas/ccmemo/compare/v1.10.2...v1.11.0
+[1.10.2]: https://github.com/LevNas/ccmemo/compare/v1.10.1...v1.10.2
+[1.10.1]: https://github.com/LevNas/ccmemo/compare/v1.10.0...v1.10.1
+[1.10.0]: https://github.com/LevNas/ccmemo/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/LevNas/ccmemo/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/LevNas/ccmemo/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/LevNas/ccmemo/compare/v1.6.0...v1.7.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ccmemo
 
+[![lint](https://github.com/LevNas/ccmemo/actions/workflows/lint.yml/badge.svg)](https://github.com/LevNas/ccmemo/actions/workflows/lint.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-7c5cff)
+
 Claude Code starts every session with a blank slate. The quirk you debugged yesterday,
 the plan you were halfway through — all gone when the session ends. ccmemo saves that
 knowledge and progress as Markdown files in your repository, so the next session picks
@@ -174,15 +178,20 @@ workflow as your code:
 - [docs/RUNBOOK-verify-hybrid-search.md](docs/RUNBOOK-verify-hybrid-search.md) — verification & corporate TLS
 - [docs/claude-md-examples.md](docs/claude-md-examples.md) — CLAUDE.md configuration
 
+## Getting help
+
+- **Usage or design questions** — open a [Question issue](https://github.com/LevNas/ccmemo/issues/new?template=question.md)
+- **Bugs & feature requests** — pick a template from [new issue](https://github.com/LevNas/ccmemo/issues/new/choose)
+- **What changed** — see the [CHANGELOG](CHANGELOG.md)
+
 ## Contributing
 
+Maintained by [@LevNas](https://github.com/LevNas); contributions and forks welcome.
 See [CONTRIBUTING.md](CONTRIBUTING.md) for scope, plugin conventions, the linter
 command, and pull request guidelines.
 
 ## License
 
-[MIT](LICENSE) — free to use, modify, and redistribute, including commercially, as long
-as you keep the copyright notice. If you build on ccmemo, a credit line is appreciated
-(not required):
+[MIT](LICENSE). If you build on ccmemo, a credit line is appreciated (not required):
 
 > Based on [ccmemo](https://github.com/LevNas/ccmemo) by LevNas.

--- a/README.md
+++ b/README.md
@@ -1,81 +1,58 @@
 # ccmemo
 
-Claude Code starts every session with a blank slate. The quirk you debugged yesterday, the plan you were halfway through — all gone when the session ends. ccmemo saves that knowledge and progress as Markdown files in your repository, so the next session picks up where you left off.
+Claude Code starts every session with a blank slate. The quirk you debugged yesterday,
+the plan you were halfway through — all gone when the session ends. ccmemo saves that
+knowledge and progress as Markdown files in your repository, so the next session picks
+up where you left off.
 
 ## What It Does
 
-- **Knowledge Base** (`/record-knowledge`): Captures tacit knowledge — quirks, pitfalls, decisions — as tagged Markdown entries in `.claude/knowledge/entries/`
-- **Plan & Task Persistence** (`/plan-task`): Maintains multi-step plans and task progress across sessions in `.claude/tasks/`
-- **Knowledge Review** (`/review-knowledge`): Maintains knowledge base health — finds stale entries, orphan entries, missing connections, and tag issues. Supports periodic review and internalization of accumulated knowledge
+ccmemo adds four slash commands that persist knowledge and plans as plain Markdown in
+`.claude/`:
+
+| Command | What it does | More |
+|---------|--------------|------|
+| `/record-knowledge` | Save a quirk, pitfall, or decision as a tagged entry | [Example](#example) |
+| `/recall-knowledge` | Hybrid semantic search across entries (synonyms, cross-language) | [docs/hybrid-search.md](docs/hybrid-search.md) |
+| `/review-knowledge` | Keep the knowledge base healthy — stale/orphan entries, missing links, tag issues | [Reviewing](#reviewing-knowledge) |
+| `/plan-task` | Persist multi-step plans and progress across sessions | [Plan & task](#plan--task-management) |
+
+Claude Code invokes these automatically when relevant; you can also trigger any of them
+by name.
 
 ## Install
 
-### Option 1: Plugin (recommended)
+### Plugin (recommended)
 
 ```bash
-# Add the marketplace
 /plugin marketplace add LevNas/claudecode-plugins
-
-# Install ccmemo
 /plugin install ccmemo@levnas-plugins
 ```
 
-Then copy the templates into your project:
+Then copy the starter templates into your project root:
 
 ```bash
-# From your project root
 cp -r path/to/ccmemo/templates/knowledge .claude/knowledge
 cp -r path/to/ccmemo/templates/tasks .claude/tasks
 ```
 
-### Option 2: Manual copy
+### Manual copy
 
-Copy the skills and templates you need into your project:
-
-```bash
-# From your project root
-
-# Knowledge base (record-knowledge)
-cp -r path/to/ccmemo/skills/record-knowledge .claude/skills/record-knowledge
-cp -r path/to/ccmemo/templates/knowledge .claude/knowledge
-
-# Plan & task persistence (plan-task)
-cp -r path/to/ccmemo/skills/plan-task .claude/skills/plan-task
-cp -r path/to/ccmemo/templates/tasks .claude/tasks
-```
-
-Your project should now have:
+If you'd rather not use the marketplace, copy just the skills and templates you need
+(e.g. `cp -r path/to/ccmemo/skills/record-knowledge .claude/skills/`). Each skill is a
+self-contained `SKILL.md`. Your project ends up with:
 
 ```
-your-project/
-└── .claude/
-    ├── skills/
-    │   ├── record-knowledge/
-    │   │   └── SKILL.md
-    │   ├── plan-task/
-    │   │   └── SKILL.md
-    │   └── review-knowledge/
-    │       └── SKILL.md
-    ├── knowledge/
-    │   ├── CLAUDE.md
-    │   └── entries/
-    │       └── .gitkeep
-    └── tasks/
-        ├── CLAUDE.md
-        └── readme.md
+your-project/.claude/
+├── skills/{record-knowledge,plan-task,review-knowledge,recall-knowledge}/SKILL.md
+├── knowledge/{CLAUDE.md,entries/}
+└── tasks/{CLAUDE.md,readme.md}
 ```
 
-## Usage
+## Example
 
-### Recording Knowledge
-
-Claude Code automatically uses `/record-knowledge` when it discovers something worth noting. You can also trigger it explicitly:
-
-```
-/record-knowledge
-```
-
-Claude Code will create an entry like `.claude/knowledge/entries/20260302-143052-alice-docker-compose-port-conflict.md`:
+`/record-knowledge` creates an entry like
+`.claude/knowledge/entries/20260302-143052-alice-docker-compose-port-conflict.md`:
 
 ```markdown
 ---
@@ -93,249 +70,89 @@ Use `ports: ["8080:80"]` or stop host nginx first.
 - see: [Nginx reverse proxy setup](nginx-reverse-proxy.md) — related configuration
 ```
 
-### Searching Entries
+See [docs/examples.md](docs/examples.md) for personal and team workflow walkthroughs.
+
+## Usage
+
+### Searching entries
+
+Quick keyword/filename lookups need no setup:
 
 ```bash
-# Fuzzy search by filename
-fd -e md . .claude/knowledge/entries/ | fzf
-
-# Search by tag
-rg '#pitfall' .claude/knowledge/entries/
-
-# List all titles
-rg '^title:' .claude/knowledge/entries/
-
-# Active entries only
-rg '^status: active' .claude/knowledge/entries/
+fd -e md . .claude/knowledge/entries/ | fzf   # fuzzy search by filename
+rg '#pitfall' .claude/knowledge/entries/      # search by tag
+rg '^title:' .claude/knowledge/entries/       # list all titles
 ```
 
-#### Semantic search (recall-knowledge, experimental)
+For meaning-based search (synonyms, or a Japanese query against English identifiers),
+`/recall-knowledge` runs hybrid semantic search — ripgrep + local vector embeddings +
+the `see:`-link graph — and falls back to ripgrep when the index is absent. Setup:
+[docs/hybrid-search.md](docs/hybrid-search.md).
 
-Beyond the keyword/filename lookups above, `/recall-knowledge` runs **hybrid semantic search** —
-ripgrep + local vector embeddings + the `see:`-link graph — so a query surfaces relevant entries
-even when worded differently (synonyms, or a Japanese query vs English identifiers). It runs
-on demand (the per-prompt hook stays ripgrep-only, instant and model-free) and falls back to
-ripgrep when the vector index or its dependencies are absent.
+### Reviewing knowledge
 
-- Setup & how it works: [docs/hybrid-search.md](docs/hybrid-search.md)
-- Verification / re-setup steps (incl. corporate TLS): [docs/RUNBOOK-verify-hybrid-search.md](docs/RUNBOOK-verify-hybrid-search.md)
+`/review-knowledge` keeps the base healthy in three modes:
 
-### Reviewing Knowledge
+- **Health check** (default) — reports stale entries (>90 days), orphans (no `see:`
+  links), missing connections, tag issues, and summary stats
+- **Topic review** (`topic:<keyword>`) — summarizes a topic and asks reflective
+  questions to verify accuracy
+- **Fix mode** (`fix`) — interactively adds missing links and registers tags
 
-Periodically run `/review-knowledge` to maintain knowledge base health:
+### Plan & task management
 
-```
-/review-knowledge
-```
+`/plan-task` persists multi-step plans in `.claude/tasks/`. Two modes:
 
-Three modes are available:
+- **Git-tracked** (default) — plans (`plan-v1.md`, `todo.md`, `readme.md`) are committed
+  and become the shared source of truth. Progress moves `[ ]` → `[~]` → `[x]`; plan
+  revisions are kept as `plan-v2.md`, etc. Each task dir also holds `context-*.md` files
+  that capture detailed working context (see [Context Guard](docs/architecture.md#context-guard-since-v110)).
+- **Issue-centric** — gitignore `.claude/tasks/` and treat your issue tracker (GitHub,
+  GitLab, Jira) as the source of truth; `.claude/tasks/` becomes a per-session
+  scratchpad. Session start checks assigned issues instead of `readme.md`.
 
-- **Health Check** (default): Scans the entire knowledge base and reports stale entries (>90 days), orphan entries (no `see:` links), missing connections (shared tags but no links), tag issues (unregistered/unused/near-duplicate), and summary statistics
-- **Topic Review** (`topic:<keyword>`): Deep dive into a specific topic — summarizes related entries and asks reflective questions to help you verify accuracy
-- **Fix Mode** (`fix`): Interactively fixes issues found in the health check — adds missing `see:` links, registers unregistered tags, and reports actions taken
+### Wiring into CLAUDE.md
 
-### Plan & Task Management
-
-Claude Code uses `/plan-task` to persist multi-step plans across sessions. Two modes are available:
-
-#### Git-tracked mode (default)
-
-`.claude/tasks/` is committed to Git and serves as the shared source of truth:
-
-1. **Create**: Start a plan with `plan-v1.md`, `todo.md`, and `readme.md` in `.claude/tasks/<slug>-<account>-<date>/`
-2. **Work**: Update `todo.md` as tasks progress (`[ ]` → `[~]` → `[x]`)
-3. **Revise**: If the plan changes, create `plan-v2.md` (previous versions are preserved)
-4. **Pause/Resume**: On session end, update the plan's `readme.md` with handoff notes. Next session checks `.claude/tasks/readme.md` for incomplete plans
-5. **Complete**: Mark done in both the plan directory and the task index
-
-If your project uses an issue tracker, plans can optionally link to issues for bidirectional progress tracking.
-
-Each task directory also contains **context-\*.md** files that capture detailed working context (investigation results, trial & error, decision rationale) too granular for plan files but essential for resuming work. These are written incrementally — both automatically by the PostToolUse hook (file changes) and manually for reasoning and analysis. See [Context Guard](#context-guard-v110) for details.
-
-#### Issue-centric mode
-
-For teams already using an issue tracker (GitLab, GitHub Issues, Jira, etc.) as the primary source of truth:
-
-1. **Gitignore tasks**: Add `.claude/tasks/` to `.gitignore`
-2. **Use issue tracker**: Plans, progress, and decisions live in the issue tracker
-3. **Local scratchpad**: `.claude/tasks/` becomes a local working memo for the current session
-4. **Session start**: Check assigned issues (e.g., `glab issue list --assignee=@me`) instead of `.claude/tasks/readme.md`
-
-### Using Knowledge in CLAUDE.md
-
-Add a lookup section to your project's `CLAUDE.md` so Claude Code checks relevant entries before starting work:
-
-```markdown
-## Knowledge Base Lookup
-
-Before starting work, search for relevant active knowledge entries:
-
-\```bash
-rg '^status: active' .claude/knowledge/entries/ -l | xargs rg '<keyword>' -l
-\```
-```
-
-For more detailed CLAUDE.md configuration examples, see [docs/claude-md-examples.md](docs/claude-md-examples.md).
-
-## Real-World Examples
-
-### Personal: Capturing knowledge from debugging sessions
-
-While debugging a CI pipeline failure, Claude Code discovers that a dependency upgrade changed its config file format. The fix is simple, but without recording the context, the next session has no idea why the config looks the way it does.
-
-With `/record-knowledge`, Claude Code saves the discovery:
-
-```markdown
----
-title: webpack 6 requires updated config format
-author: "@alice"
-created: 2026-03-08
-status: active
-tags: "#webpack #migration #pitfall"
----
-
-webpack 6 dropped support for `module.rules[].loader` shorthand.
-Must use `module.rules[].use` array format instead.
-
-The CI failure after the upgrade was caused by this breaking change.
-- ref: https://webpack.js.org/migrate/6/
-- see: [Node.js 22 upgrade notes](nodejs-22-upgrade.md)
-```
-
-The next session — or a teammate's session — finds this entry automatically and avoids repeating the same investigation.
-
-### Team: Syncing progress through issue tracker
-
-A team manages their project roadmap in GitHub Issues. Each member uses Claude Code in their own session, but progress needs to stay visible to everyone.
-
-With `/plan-task` in issue-centric mode, Claude Code checks assigned issues at session start (`gh issue list --assignee=@me`) and posts progress comments when work is done. The issue's checklist is updated directly — no manual copy-paste between sessions.
-
-```markdown
-## Progress Update (2026-03-08)
-
-### Completed
-- Migrated database schema to v3
-- Added index on `users.email` column
-
-### Next Steps
-- Update API validation to match new schema constraints
-```
-
-Every team member sees the latest state in the issue tracker, regardless of who worked on it or which Claude Code session produced the update.
-
-## Why Use It in a Git Repository
-
-Both skills store data as plain Markdown files in your repository. This means they follow the same branch/merge/review workflow as your code, and bring additional benefits:
-
-- **Team sharing**: Knowledge entries and plans committed to Git are available to every team member — and every Claude Code session they start. A pitfall one person discovers on Monday is available to the entire team on Tuesday.
-- **Session continuity**: Plans and knowledge survive across Claude Code sessions. No more re-explaining context or re-discovering the same issues.
-- **Browsable**: All files render cleanly in GitHub and GitLab's web UI — no special tooling needed.
+Add a lookup section to your project's `CLAUDE.md` so Claude checks relevant entries
+before starting work. Patterns and examples: [docs/claude-md-examples.md](docs/claude-md-examples.md).
 
 ## Customization
 
-### Tags (Knowledge Base)
+- **Tags** — maintain a registry in `.claude/knowledge/CLAUDE.md` (lowercase
+  kebab-case, `#` prefix). Claude checks it before creating new tags.
+- **Author** — the entry `author` field defaults to `@<username>`; set it to your Git
+  hosting username.
+- **Workflow** — edit any `skills/*/SKILL.md` to add project-specific conventions
+  (tag categories, issue-tracker comment formats, plan templates).
 
-Edit `.claude/knowledge/CLAUDE.md` to maintain a tag registry for your project. Tags use lowercase kebab-case with `#` prefix as a flat list:
+## Why Use It in a Git Repository
 
-```
-`#docker` `#postgresql` `#react` `#pitfall` `#workaround` `#design-practice`
-```
+Everything is plain Markdown in your repo, so it follows the same branch/merge/review
+workflow as your code:
 
-Claude Code checks the registry before creating new tags to avoid duplicates.
+- **Team sharing** — a pitfall one person finds on Monday is available to everyone
+  (and every Claude Code session) on Tuesday.
+- **Session continuity** — plans and knowledge survive across sessions; no
+  re-explaining context or re-discovering the same issues.
+- **Browsable** — files render cleanly in GitHub and GitLab with no special tooling.
 
-### Entry Author (Knowledge Base)
+## Documentation
 
-The `author` field in entries defaults to `@<username>`. Set this to match your Git hosting platform username.
-
-### Issue Tracker Integration (Plan & Task)
-
-Plans can optionally link to issues. Edit `skills/plan-task/SKILL.md` to add project-specific conventions — for example, specifying your issue tracker's comment format or commit message conventions.
-
-### Integration with Project Workflow
-
-You can extend either skill by editing its `SKILL.md` to fit your workflow — for example, adding project-specific tag categories, linking to your issue tracker, or customizing plan templates.
-
-## Subagent Delegation (v1.8.0)
-
-Both `record-knowledge` and `plan-task` skills delegate their execution to a Sonnet subagent. This keeps the main conversation context lean while the subagent handles file I/O and knowledge graph maintenance.
-
-### Structured Input Template
-
-The main agent prepares four structured fields before delegating:
-
-| Field | Purpose |
-|-------|---------|
-| `what` | Factual observation or decision |
-| `why` | Reasoning behind recording it |
-| `context` | Related issues, branches, files |
-| `tags_hint` | Recommended tags (validated by subagent) |
-
-This separation ensures consistent entry quality regardless of how the main agent phrases its instructions.
-
-### Plan-Task Operation Modes
-
-`plan-task` uses an explicit operation mode to guide the subagent:
-
-| Mode | When |
-|------|------|
-| `session-start` | New session, post-compaction, resume |
-| `create-plan` | Starting a new multi-step plan |
-| `update-progress` | Progress update or break signal |
-| `revise-plan` | Plan approach needs to change |
-| `pause` | Taking a break, session end |
-| `complete` | All tasks done, wrap up |
-
-## Context Guard (v1.1.0)
-
-Prevents knowledge loss during context compaction with a three-stage defense:
-
-### How It Works
-
-| Stage | Event | Role | Can Block? |
-|-------|-------|------|------------|
-| 1st | PostToolUse | Appends file changes to active task's `context-*.md` | NO (side effect) |
-| 2nd | Stop | Prompts `/record-knowledge` when context grows large | YES |
-| 3rd | PreCompact | Saves checkpoint of modified files & decisions | NO (side effect) |
-
-**Stage 1 (PostToolUse hook):** Every time Write or Edit tools modify a file, the change is automatically appended to the active task's `context-*.md` file. This provides incremental context capture that survives context compaction. Only fires when an active task exists in `.claude/tasks/readme.md`.
-
-**Stage 2 (Stop hook):** When the transcript exceeds 300KB and no knowledge entry has been recorded recently, Claude pauses and asks if you want to run `/record-knowledge`. Answer "不要" to skip.
-
-**Stage 3 (PreCompact hook):** Before compaction, a checkpoint is automatically saved to `.claude/context-checkpoints/` with modified file paths and user decisions extracted from the transcript tail.
-
-### Checkpoint Lifecycle
-
-Checkpoints saved by the PreCompact hook are consumed by `/plan-task` on the next session start or after compaction:
-
-1. Read each checkpoint file in `.claude/context-checkpoints/`
-2. Integrate modified file lists and user decisions into the active task's `context-*.md`
-3. If a checkpoint contains knowledge-worthy findings, invoke `/record-knowledge`
-4. Delete consumed checkpoint files
-
-The `.claude/context-checkpoints/` directory is created on-demand when the first compaction occurs — it does not exist until then.
-
-### Configuration
-
-Set the size threshold for the Stop hook via environment variable:
-
-```bash
-export CCMEMO_CONTEXT_GUARD_THRESHOLD_KB=500  # default: 300
-```
-
-### Disabling
-
-Remove or comment out the relevant entry in `hooks/hooks.json`, or delete the `hooks/` directory.
+- [docs/architecture.md](docs/architecture.md) — subagent delegation, Context Guard, internals
+- [docs/examples.md](docs/examples.md) — personal & team workflow walkthroughs
+- [docs/hybrid-search.md](docs/hybrid-search.md) — semantic search setup
+- [docs/RUNBOOK-verify-hybrid-search.md](docs/RUNBOOK-verify-hybrid-search.md) — verification & corporate TLS
+- [docs/claude-md-examples.md](docs/claude-md-examples.md) — CLAUDE.md configuration
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for the project's scope, plugin conventions (document placement, SKILL.md frontmatter, the central linter command), pull request guidelines, and attribution requests for forks.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for scope, plugin conventions, the linter
+command, and pull request guidelines.
 
 ## License
 
-This project is licensed under the [MIT License](LICENSE) — see the `LICENSE` file for the full text.
-
-In short: you're free to use, modify, and redistribute ccmemo, including for commercial purposes, as long as you keep the copyright notice and license text.
-
-If you build something based on ccmemo, a credit line is appreciated (not required):
+[MIT](LICENSE) — free to use, modify, and redistribute, including commercially, as long
+as you keep the copyright notice. If you build on ccmemo, a credit line is appreciated
+(not required):
 
 > Based on [ccmemo](https://github.com/LevNas/ccmemo) by LevNas.

--- a/README.md
+++ b/README.md
@@ -20,27 +20,54 @@ ccmemo adds four slash commands that persist knowledge and plans as plain Markdo
 Claude Code invokes these automatically when relevant; you can also trigger any of them
 by name.
 
-## Install
+## Quick start
 
-### Plugin (recommended)
+Up and running in three steps. The plugin is the recommended path — skills and hooks
+activate the moment it's installed.
 
-```bash
+**1. Install the plugin** (in Claude Code):
+
+```
 /plugin marketplace add LevNas/claudecode-plugins
 /plugin install ccmemo@levnas-plugins
 ```
 
-Then copy the starter templates into your project root:
+That alone makes `/record-knowledge`, `/plan-task`, `/review-knowledge`, and
+`/recall-knowledge` available and wires up the [Context Guard](docs/architecture.md#context-guard-since-v110) hooks.
+
+**2. Scaffold the starter config** into your project — a tag registry for knowledge and
+an index for tasks. Easiest is to just ask Claude Code:
+
+> Scaffold ccmemo's knowledge and tasks templates into `.claude/`.
+
+Prefer a command? From your project root:
 
 ```bash
-cp -r path/to/ccmemo/templates/knowledge .claude/knowledge
-cp -r path/to/ccmemo/templates/tasks .claude/tasks
+tpl=$(find ~/.claude/plugins/cache -type d -path '*ccmemo*/templates' | sort | tail -1)
+cp -r "$tpl/knowledge" .claude/knowledge
+cp -r "$tpl/tasks"     .claude/tasks
 ```
 
-### Manual copy
+**3. Try it.** Run `/record-knowledge` and describe something worth remembering — Claude
+writes a Markdown entry under `.claude/knowledge/entries/`. Commit it, and your next
+session (or a teammate's) finds it automatically.
 
-If you'd rather not use the marketplace, copy just the skills and templates you need
-(e.g. `cp -r path/to/ccmemo/skills/record-knowledge .claude/skills/`). Each skill is a
-self-contained `SKILL.md`. Your project ends up with:
+> Semantic search via `/recall-knowledge` is opt-in (one-time index build) — see
+> [docs/hybrid-search.md](docs/hybrid-search.md).
+
+### Without the marketplace
+
+Copy the skills and templates straight from the repo:
+
+```bash
+git clone --depth 1 https://github.com/LevNas/ccmemo /tmp/ccmemo
+cp -r /tmp/ccmemo/skills/*            .claude/skills/      # the four skills
+cp -r /tmp/ccmemo/templates/knowledge .claude/knowledge
+cp -r /tmp/ccmemo/templates/tasks     .claude/tasks
+rm -rf /tmp/ccmemo
+```
+
+Your project ends up with:
 
 ```
 your-project/.claude/
@@ -48,6 +75,9 @@ your-project/.claude/
 ├── knowledge/{CLAUDE.md,entries/}
 └── tasks/{CLAUDE.md,readme.md}
 ```
+
+Hooks (Context Guard) are wired through the plugin; with a manual copy, add the
+`hooks/hooks.json` entries yourself if you want them.
 
 ## Example
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,86 @@
+# Architecture & Internals
+
+How ccmemo works under the hood. You don't need any of this to use the skills —
+it's here for contributors and anyone curious about the design.
+
+## Subagent Delegation (since v1.8.0)
+
+Both `record-knowledge` and `plan-task` delegate their execution to a Sonnet
+subagent. This keeps the main conversation context lean while the subagent handles
+file I/O and knowledge graph maintenance.
+
+### Structured input template
+
+The main agent prepares four structured fields before delegating:
+
+| Field | Purpose |
+|-------|---------|
+| `what` | Factual observation or decision |
+| `why` | Reasoning behind recording it |
+| `context` | Related issues, branches, files |
+| `tags_hint` | Recommended tags (validated by subagent) |
+
+This separation ensures consistent entry quality regardless of how the main agent
+phrases its instructions.
+
+### Plan-task operation modes
+
+`plan-task` uses an explicit operation mode to guide the subagent:
+
+| Mode | When |
+|------|------|
+| `session-start` | New session, post-compaction, resume |
+| `create-plan` | Starting a new multi-step plan |
+| `update-progress` | Progress update or break signal |
+| `revise-plan` | Plan approach needs to change |
+| `pause` | Taking a break, session end |
+| `complete` | All tasks done, wrap up |
+
+## Context Guard (since v1.1.0)
+
+Prevents knowledge loss during context compaction with a three-stage defense:
+
+| Stage | Event | Role | Can Block? |
+|-------|-------|------|------------|
+| 1st | PostToolUse | Appends file changes to active task's `context-*.md` | NO (side effect) |
+| 2nd | Stop | Prompts `/record-knowledge` when context grows large | YES |
+| 3rd | PreCompact | Saves checkpoint of modified files & decisions | NO (side effect) |
+
+**Stage 1 (PostToolUse hook):** Every time Write or Edit modifies a file, the change
+is automatically appended to the active task's `context-*.md` file. This provides
+incremental context capture that survives compaction. Only fires when an active task
+exists in `.claude/tasks/readme.md`.
+
+**Stage 2 (Stop hook):** When the transcript exceeds 300KB and no knowledge entry has
+been recorded recently, Claude pauses and asks if you want to run `/record-knowledge`.
+Answer "不要" to skip.
+
+**Stage 3 (PreCompact hook):** Before compaction, a checkpoint is automatically saved
+to `.claude/context-checkpoints/` with modified file paths and user decisions extracted
+from the transcript tail.
+
+### Checkpoint lifecycle
+
+Checkpoints saved by the PreCompact hook are consumed by `/plan-task` on the next
+session start or after compaction:
+
+1. Read each checkpoint file in `.claude/context-checkpoints/`
+2. Integrate modified file lists and user decisions into the active task's `context-*.md`
+3. If a checkpoint contains knowledge-worthy findings, invoke `/record-knowledge`
+4. Delete consumed checkpoint files
+
+The `.claude/context-checkpoints/` directory is created on-demand when the first
+compaction occurs — it does not exist until then.
+
+### Configuration
+
+Set the size threshold for the Stop hook via environment variable:
+
+```bash
+export CCMEMO_CONTEXT_GUARD_THRESHOLD_KB=500  # default: 300
+```
+
+### Disabling
+
+Remove or comment out the relevant entry in `hooks/hooks.json`, or delete the
+`hooks/` directory.

--- a/docs/claude-md-examples.md
+++ b/docs/claude-md-examples.md
@@ -79,9 +79,18 @@ rg '^status: active' .claude/knowledge/entries/ -l | xargs rg '<keyword>' -l
 \```
 Then Read the matching file.
 
+### Search by meaning (keyword search came up empty)
+
+When literal keywords miss — synonyms, or a query worded differently from the entries
+(e.g. a Japanese query against English identifiers) — run the `/recall-knowledge` skill.
+It does hybrid semantic search (ripgrep + local vector embeddings + the `see:`-link graph)
+and falls back to ripgrep when the index is unavailable, so it is always safe to try.
+
 ### Rules
 - Only reference entries with `status: active` — ignore `deprecated` entries
 - Replace `<keyword>` with terms relevant to the current task (service name, technology, etc.)
+- If keyword search returns nothing relevant, retry with `/recall-knowledge` before
+  concluding "no knowledge entry found"
 ```
 
 ## Plan Persistence (Git-tracked mode)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,54 @@
+# Real-World Examples
+
+Concrete scenarios showing how ccmemo fits into everyday work.
+
+## Personal: Capturing knowledge from debugging sessions
+
+While debugging a CI pipeline failure, Claude Code discovers that a dependency upgrade
+changed its config file format. The fix is simple, but without recording the context,
+the next session has no idea why the config looks the way it does.
+
+With `/record-knowledge`, Claude Code saves the discovery:
+
+```markdown
+---
+title: webpack 6 requires updated config format
+author: "@alice"
+created: 2026-03-08
+status: active
+tags: "#webpack #migration #pitfall"
+---
+
+webpack 6 dropped support for `module.rules[].loader` shorthand.
+Must use `module.rules[].use` array format instead.
+
+The CI failure after the upgrade was caused by this breaking change.
+- ref: https://webpack.js.org/migrate/6/
+- see: [Node.js 22 upgrade notes](nodejs-22-upgrade.md)
+```
+
+The next session — or a teammate's session — finds this entry automatically and avoids
+repeating the same investigation.
+
+## Team: Syncing progress through an issue tracker
+
+A team manages their project roadmap in GitHub Issues. Each member uses Claude Code in
+their own session, but progress needs to stay visible to everyone.
+
+With `/plan-task` in issue-centric mode, Claude Code checks assigned issues at session
+start (`gh issue list --assignee=@me`) and posts progress comments when work is done.
+The issue's checklist is updated directly — no manual copy-paste between sessions.
+
+```markdown
+## Progress Update (2026-03-08)
+
+### Completed
+- Migrated database schema to v3
+- Added index on `users.email` column
+
+### Next Steps
+- Update API validation to match new schema constraints
+```
+
+Every team member sees the latest state in the issue tracker, regardless of who worked
+on it or which Claude Code session produced the update.

--- a/templates/knowledge/CLAUDE.md
+++ b/templates/knowledge/CLAUDE.md
@@ -20,6 +20,10 @@ One entry per file with YAML frontmatter.
 
 ## Search
 
+### Keyword / tag search
+
+Instant, no setup — use when you know the literal term or tag:
+
 ```bash
 # Fuzzy search by filename
 fd -e md . .claude/knowledge/entries/ | fzf
@@ -34,6 +38,15 @@ rg '^title:' .claude/knowledge/entries/
 # Active entries only
 rg '^status: active' .claude/knowledge/entries/
 ```
+
+### Semantic search (by meaning)
+
+When keywords might miss the entry — synonyms, or a Japanese query against English
+identifiers — use the `/recall-knowledge` skill. It runs hybrid search (ripgrep +
+local vector embeddings + the `see:`-link graph) and falls back to ripgrep-only when
+the vector index or its optional dependencies are absent, so it never breaks. On-demand
+only; the per-prompt auto-injection hook stays ripgrep (instant, no model load). Setup:
+see the plugin's `docs/hybrid-search.md`.
 
 ## Tag Registry
 


### PR DESCRIPTION
## Summary

Documentation-only changes (no code/skill behavior changes).

- **README restructure** — trim the 341-line README to a scannable front door; move internals to `docs/architecture.md` and walkthroughs to `docs/examples.md`
- **Surface semantic search** — `/recall-knowledge` was only in its own doc; add it to the shipped `templates/knowledge/CLAUDE.md` Search section and the `docs/claude-md-examples.md` lookup example so projects actually wire it in
- **Inviting Quick start** — replace the vague `path/to/ccmemo` install with a 3-step quick start (install → scaffold → try), a version-independent scaffold command, and a no-marketplace fallback
- **GitHub README rubric** — add badges (lint CI, MIT), a Getting help section, maintainer line; trim the License section to reference `LICENSE`
- **CHANGELOG backfill** — add the missing `v1.10.2` entry and the `1.10.0/1.10.1/1.10.2/1.11.0` compare links to match the tags now published

## Notes

- Tags and GitHub Releases for v1.9.0–v1.11.0 were published separately (they point at historical main commits); this PR only brings the CHANGELOG in line with them.
- Lint workflow is unaffected (no `SKILL.md` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)