### PR TITLE
fix(scripts): make semantic search work on NixOS via libstdc++ preflight

### DIFF
--- a/docs/hybrid-search.md
+++ b/docs/hybrid-search.md
@@ -100,6 +100,16 @@ chmod +x .git/hooks/post-merge
 # adjust CCMEMO_KB_ROOT / CCMEMO_KB_INDEX env vars if your layout differs
 ```
 
+## NixOS
+
+On NixOS, numpy's manylinux wheel cannot resolve `libstdc++.so.6` when the
+scripts run under the Nix-native CPython (nix-ld's `NIX_LD_LIBRARY_PATH` is not
+consulted for it, because that interpreter does not go through the nix-ld shim).
+Both scripts detect this at startup and re-exec themselves once with
+`LD_LIBRARY_PATH` pointing at gcc's libstdc++ directory
+(`gcc -print-file-name=libstdc++.so.6`), so no manual setup is needed as long
+as `gcc` is on `PATH`. See issue #13 for the full analysis.
+
 ## Status
 
 Experimental vertical slice. It is **not wired into**

--- a/scripts/kb_index.py
+++ b/scripts/kb_index.py
@@ -55,6 +55,56 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
+
+def _nixos_libstdcxx_preflight() -> None:
+    """NixOS: re-exec with libstdc++ on LD_LIBRARY_PATH if numpy cannot load it.
+
+    numpy's manylinux wheel (a transitive dep of fastembed) needs libstdc++.so.6,
+    which the Nix-native CPython cannot resolve: that interpreter is not loaded
+    through the nix-ld shim, so NIX_LD_LIBRARY_PATH is never consulted and the
+    import dies with "libstdc++.so.6: cannot open shared object file". Plain
+    LD_LIBRARY_PATH is the only effective channel, so re-exec once with it
+    pointing at gcc's libstdc++ directory. No-op on other platforms and on
+    already-working setups. See https://github.com/LevNas/ccmemo/issues/13.
+    """
+    import os
+
+    if not os.path.exists("/etc/NIXOS") or os.environ.get("CCMEMO_LIBSTDCXX_REEXEC"):
+        return
+    try:
+        import numpy  # noqa: F401
+        return
+    except ImportError as exc:
+        if "libstdc++" not in str(exc):
+            return
+
+    import shutil
+    import subprocess
+
+    gcc = shutil.which("gcc")
+    if not gcc:
+        return  # nothing we can do; let the import error surface at first use
+    try:
+        libstdcxx = subprocess.run(
+            [gcc, "-print-file-name=libstdc++.so.6"],
+            capture_output=True, text=True, timeout=10,
+        ).stdout.strip()
+    except (OSError, subprocess.SubprocessError):
+        return
+    if not libstdcxx.startswith("/"):
+        return  # gcc echoes the bare name back when it cannot resolve the file
+
+    env = dict(os.environ)
+    libdir = os.path.dirname(libstdcxx)
+    env["LD_LIBRARY_PATH"] = (
+        f"{libdir}:{env['LD_LIBRARY_PATH']}" if env.get("LD_LIBRARY_PATH") else libdir
+    )
+    env["CCMEMO_LIBSTDCXX_REEXEC"] = "1"
+    os.execve(sys.executable, [sys.executable, *sys.argv], env)
+
+
+_nixos_libstdcxx_preflight()
+
 EMBED_MODEL = "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2"
 EMBED_DIM = 384
 # Entries longer than this many characters also get per-`##`-section chunks.


### PR DESCRIPTION
## Summary

Fixes #13 — on NixOS, the semantic layer of hybrid search crashed with
`ImportError: libstdc++.so.6: cannot open shared object file` because numpy's
manylinux wheel cannot resolve libstdc++ under the Nix-native CPython
(nix-ld's `NIX_LD_LIBRARY_PATH` is not consulted for that interpreter, and
RUNPATH does not propagate to dlopen'ed extension deps).

## Change

- `scripts/kb_index.py`: add a module-import-time preflight. On NixOS
  (`/etc/NIXOS` present), if `import numpy` fails with a libstdc++ error,
  re-exec once with `LD_LIBRARY_PATH` pointing at gcc's libstdc++ directory
  (resolved via `gcc -print-file-name=libstdc++.so.6`). A sentinel env var
  (`CCMEMO_LIBSTDCXX_REEXEC`) prevents loops. `kb_search.py` is covered
  automatically because it imports `kb_index` at startup.
- `docs/hybrid-search.md`: add a NixOS section describing the behaviour.

The guard is a single `os.path.exists` check on non-NixOS platforms and a
no-op on already-working NixOS setups (including uv-managed portable builds
that resolve libstdc++ on their own).

## Verification (on NixOS)

- Without `LD_LIBRARY_PATH`: `uv run scripts/kb_search.py <kb> "<Japanese query>"`
  auto-re-execs and returns semantic results; index build works the same way.
- With `CCMEMO_LIBSTDCXX_REEXEC=1` preset: the original ImportError surfaces
  unchanged — no re-exec loop.
- `lint-skills.sh`: 24 checks, 0 warnings, 0 errors.

## Alternatives considered

- `programs.nix-ld.libraries` + `stdenv.cc.cc.lib`: verified ineffective — the
  module's default set already contains libstdc++, but the Nix-native Python
  never goes through the nix-ld shim.
- System-wide `LD_LIBRARY_PATH`: works but is a NixOS anti-pattern (global
  library-version bleed).
