### PR TITLE
Add kb_graph.py link-graph CLI and wire it into recall/review skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- `scripts/kb_graph.py` — link-graph CLI over the knowledge base: `stats` (hubs,
+  orphans, connected components), `neighborhood` (BFS around an entry), `path`
+  (shortest link path), and a deterministic `lint` (broken/out-of-tree/self/duplicate
+  links, missing titles, filename format, unregistered tags; exit 1 on findings, so it
+  slots into pre-commit). Pure stdlib — no uv, no index, no network. The graph is
+  built on demand from `- see:` / `- ref:` links (no persisted index to go stale), and
+  query output is structure only (IDs, titles, edge kinds — never body text), so it
+  stays cheap to keep in a model context.
+- `tests/test_kb_graph.py` — dependency-free self-tests over a synthetic knowledge
+  base (link resolution, broken-link vs out-of-tree classification, components, CLI
+  JSON output, lint exit codes and file scoping).
+
+### Changed
+- `recall-knowledge` skill: multi-hop recalls (tracing how a decision evolved,
+  connecting two topics, mapping an area) now query graph structure first via
+  `kb_graph.py neighborhood` / `path` and read only the endpoint entries, instead of
+  chaining search → read → follow links → read again.
+- `review-knowledge` skill: the main agent precomputes `kb_graph.py stats` + `lint`
+  (deterministic, ~1s) and passes the output to the review subagent, which spends its
+  effort on judgment work (staleness, missing connections, synthesis) instead of
+  re-deriving link facts by hand. Skill now allows Bash for that precompute step;
+  graceful fallback to the previous read-everything behaviour when `python3` is
+  unavailable.
+
 ## [1.13.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.15.0] - 2026-07-27
 
 ### Added
 - `scripts/kb_graph.py` — link-graph CLI over the knowledge base: `stats` (hubs,

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ For meaning-based search (synonyms, or a Japanese query against English identifi
 the `see:`-link graph — and falls back to ripgrep when the index is absent. Setup:
 [docs/hybrid-search.md](docs/hybrid-search.md).
 
+For multi-hop questions ("how did this decision evolve", "how do X and Y connect"),
+`scripts/kb_graph.py` queries the `see:`-link graph directly — `stats`, `neighborhood`,
+`path`, and a deterministic `lint` (pre-commit friendly). Pure stdlib, no index: the
+graph is built on demand from the entries, and output is structure only (IDs, titles,
+edge kinds — no body text), so you read only the entries the structure points at.
+
+```bash
+python3 scripts/kb_graph.py stats                    # hubs, orphans, components
+python3 scripts/kb_graph.py neighborhood <entry> --depth 2
+python3 scripts/kb_graph.py path <entry-a> <entry-b> # shortest link path
+python3 scripts/kb_graph.py lint                     # exit 1 on findings
+```
+
 ### Reviewing knowledge
 
 `/review-knowledge` keeps the base healthy in three modes:

--- a/scripts/kb_graph.py
+++ b/scripts/kb_graph.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Link-graph CLI over a ccmemo knowledge base.
+
+Builds the entry graph on demand from `- see:` / `- ref:` list links
+(no persisted index; ~1s for a few hundred entries). Pure stdlib —
+runs with plain python3, no uv, no vector index, no network.
+
+Subcommands:
+  stats                  graph overview: hubs, orphans, components
+  neighborhood <entry>   BFS neighborhood (structure only, no body text)
+  path <a> <b>           shortest link path between two entries
+  lint [files...]        deterministic checks (pre-commit friendly, exit 1 on findings)
+
+Output contains entry IDs, titles and edge types only — never body text —
+so results stay cheap to inject into a model context. The intended flow is
+structure first, bodies last: use neighborhood/path to plan where to go,
+then read only the endpoint entries.
+
+lint is deterministic by design (no model calls) so it can gate commits;
+judgment work such as staleness review stays in /review-knowledge.
+
+Usage (from the project root):
+    python3 scripts/kb_graph.py stats
+    python3 scripts/kb_graph.py neighborhood <partial-name> --depth 2
+    python3 scripts/kb_graph.py path <partial-name-a> <partial-name-b>
+    python3 scripts/kb_graph.py lint [changed-files...]
+
+Entries are addressed by unique filename substring. `--json` gives
+machine-readable output. `--root` points at the entries dir
+(default: .claude/knowledge/entries).
+
+pre-commit example (fires only when staged entries changed):
+    changed=$(git diff --cached --name-only -- .claude/knowledge/entries/)
+    [ -z "$changed" ] || python3 scripts/kb_graph.py lint $changed
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import deque
+
+LINK_RE = re.compile(r"^\s*-\s+(see|ref):\s*\[([^\]]*)\]\(([^)]+)\)", re.MULTILINE)
+# Both registry line forms in use: "- #tag — description (count)" and "`#tag`"
+TAG_REGISTRY_RES = (
+    re.compile(r"^- (#[\w\-]+)", re.MULTILINE),
+    re.compile(r"^`(#[\w\-]+)`$", re.MULTILINE),
+)
+FILENAME_RE = re.compile(r"^\d{8}-\d{6}-.+\.md$")
+
+
+def parse_frontmatter(text):
+    meta = {}
+    if not text.startswith("---"):
+        return meta
+    end = text.find("\n---", 3)
+    if end == -1:
+        return meta
+    for line in text[3:end].splitlines():
+        m = re.match(r"^(\w+):\s*(.*)$", line.strip())
+        if m:
+            meta[m.group(1)] = m.group(2).strip().strip('"')
+    return meta
+
+
+def load_graph(root):
+    """Return (nodes, edges, problems).
+
+    nodes: {id: {"title", "tags", "status"}} — id is path relative to entries root
+    edges: [(src, dst, kind, resolution)] — resolution: "root" | "fallback"
+    problems: lint findings collected during parsing
+    """
+    root = os.path.abspath(root)
+    nodes, edges, problems = {}, [], []
+    for dirpath, _dirnames, filenames in os.walk(root):
+        for fn in sorted(filenames):
+            if not fn.endswith(".md") or fn == "CLAUDE.md":
+                continue
+            path = os.path.join(dirpath, fn)
+            nid = os.path.relpath(path, root)
+            with open(path, encoding="utf-8", errors="replace") as f:
+                text = f.read()
+            meta = parse_frontmatter(text)
+            nodes[nid] = {
+                "title": meta.get("title", ""),
+                "tags": set(re.findall(r"#[\w\-]+", meta.get("tags", ""))),
+                "status": meta.get("status", ""),
+            }
+            if not meta.get("title"):
+                problems.append((nid, "missing-title", "no frontmatter title"))
+            if not FILENAME_RE.match(fn):
+                problems.append((nid, "filename", "does not match <date>-<time>-...-<slug>.md"))
+            for kind, _label, target in LINK_RE.findall(text):
+                t = target.split("#")[0].strip()
+                if not t or t.startswith(("http://", "https://")):
+                    continue
+                cand_root = os.path.normpath(os.path.join(root, t))
+                cand_file = os.path.normpath(os.path.join(dirpath, t))
+                if os.path.exists(cand_root):
+                    resolved, resolution = cand_root, "root"
+                elif os.path.exists(cand_file):
+                    resolved, resolution = cand_file, "fallback"
+                else:
+                    # targets escaping the repository resolve differently per
+                    # checkout location (worktrees, other machines) — report
+                    # them separately from links broken inside the repo.
+                    # assumes root is <repo>/.claude/knowledge/entries
+                    repo_root = os.path.normpath(os.path.join(root, "..", "..", ".."))
+                    in_repo = (cand_root.startswith(repo_root + os.sep)
+                               or cand_file.startswith(repo_root + os.sep))
+                    check = "broken-link" if in_repo else "out-of-tree"
+                    problems.append((nid, check, f"{kind}: ({t}) resolves to no file"))
+                    continue
+                if resolved.startswith(root + os.sep):
+                    dst = os.path.relpath(resolved, root)
+                    if dst == nid:
+                        problems.append((nid, "self-link", f"{kind}: links to itself"))
+                        continue
+                    edges.append((nid, dst, kind, resolution))
+                # links leaving the entries tree (rules, docs...) are checked
+                # for existence above but are not part of the entry graph
+    seen = set()
+    deduped = []
+    for e in edges:
+        key = e[:3]
+        if key in seen:
+            problems.append((e[0], "duplicate-link", f"{e[2]}: ({e[1]}) listed more than once"))
+            continue
+        seen.add(key)
+        deduped.append(e)
+    return nodes, deduped, problems
+
+
+def adjacency(nodes, edges):
+    out_adj = {n: [] for n in nodes}
+    in_adj = {n: [] for n in nodes}
+    for src, dst, kind, _res in edges:
+        if src in out_adj and dst in in_adj:
+            out_adj[src].append((dst, kind))
+            in_adj[dst].append((src, kind))
+    return out_adj, in_adj
+
+
+def components(nodes, edges):
+    parent = {n: n for n in nodes}
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for src, dst, _kind, _res in edges:
+        if src in parent and dst in parent:
+            parent[find(src)] = find(dst)
+    comps = {}
+    for n in nodes:
+        comps.setdefault(find(n), []).append(n)
+    return sorted(comps.values(), key=len, reverse=True)
+
+
+def resolve_entry(nodes, query):
+    if query in nodes:
+        return query
+    matches = [n for n in nodes if query in n]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        sys.exit(f"error: no entry matches '{query}'")
+    sys.exit("error: ambiguous query '%s' (%d matches):\n  %s"
+             % (query, len(matches), "\n  ".join(sorted(matches)[:10])))
+
+
+def short(title, width=70):
+    return title if len(title) <= width else title[: width - 1] + "…"
+
+
+def cmd_stats(nodes, edges, as_json):
+    out_adj, in_adj = adjacency(nodes, edges)
+    degree = {n: len(out_adj[n]) + len(in_adj[n]) for n in nodes}
+    hubs = sorted(nodes, key=lambda n: degree[n], reverse=True)[:10]
+    orphans = sorted(n for n in nodes if degree[n] == 0)
+    comps = components(nodes, edges)
+    kinds = {}
+    for _s, _d, k, _r in edges:
+        kinds[k] = kinds.get(k, 0) + 1
+    if as_json:
+        print(json.dumps({
+            "nodes": len(nodes), "edges": len(edges), "edge_kinds": kinds,
+            "hubs": [{"id": n, "in": len(in_adj[n]), "out": len(out_adj[n]),
+                      "title": nodes[n]["title"]} for n in hubs],
+            "orphans": orphans,
+            "components": [len(c) for c in comps],
+        }, ensure_ascii=False, indent=1))
+        return
+    print(f"nodes: {len(nodes)}  edges: {len(edges)}  ({', '.join(f'{k}={v}' for k, v in sorted(kinds.items()))})")
+    print(f"components: {len(comps)}  sizes: {[len(c) for c in comps[:8]]}"
+          + (" ..." if len(comps) > 8 else ""))
+    print("\ntop hubs (in/out):")
+    for n in hubs:
+        print(f"  {len(in_adj[n]):3d}/{len(out_adj[n]):<3d} {n}")
+        print(f"          {short(nodes[n]['title'])}")
+    print(f"\norphans (no links in either direction): {len(orphans)}")
+    for n in orphans:
+        print(f"  {n}  {short(nodes[n]['title'], 50)}")
+
+
+def cmd_neighborhood(nodes, edges, start, depth, as_json):
+    out_adj, in_adj = adjacency(nodes, edges)
+    visited = {start: 0}
+    rows = []
+    q = deque([start])
+    while q:
+        cur = q.popleft()
+        if visited[cur] >= depth:
+            continue
+        neigh = [(dst, kind, "→") for dst, kind in out_adj[cur]] + \
+                [(src, kind, "←") for src, kind in in_adj[cur]]
+        for other, kind, direction in neigh:
+            if other not in visited:
+                visited[other] = visited[cur] + 1
+                rows.append((visited[other], cur, direction, kind, other))
+                q.append(other)
+    if as_json:
+        print(json.dumps({"start": start, "depth": depth,
+                          "neighbors": [{"depth": d, "from": c, "dir": dr, "kind": k,
+                                         "id": o, "title": nodes[o]["title"]}
+                                        for d, c, dr, k, o in rows]},
+                         ensure_ascii=False, indent=1))
+        return
+    print(f"{start}\n  {short(nodes[start]['title'])}\n")
+    for d, _cur, direction, kind, other in rows:
+        print(f"  d{d} {direction}{kind:<4} {other}")
+        print(f"           {short(nodes[other]['title'])}")
+    print(f"\n{len(rows)} entries within depth {depth}")
+
+
+def cmd_path(nodes, edges, a, b, as_json):
+    out_adj, in_adj = adjacency(nodes, edges)
+    prev = {a: None}
+    q = deque([a])
+    while q and b not in prev:
+        cur = q.popleft()
+        neigh = [(dst, kind, "→") for dst, kind in out_adj[cur]] + \
+                [(src, kind, "←") for src, kind in in_adj[cur]]
+        for other, kind, direction in neigh:
+            if other not in prev:
+                prev[other] = (cur, kind, direction)
+                q.append(other)
+    if b not in prev:
+        print(f"no path between\n  {a}\n  {b}")
+        sys.exit(1)
+    chain = []
+    cur = b
+    while prev[cur]:
+        parent, kind, direction = prev[cur]
+        chain.append((parent, direction, kind, cur))
+        cur = parent
+    chain.reverse()
+    if as_json:
+        print(json.dumps({"hops": len(chain),
+                          "path": [{"from": p, "dir": d, "kind": k, "to": t}
+                                   for p, d, k, t in chain]}, ensure_ascii=False, indent=1))
+        return
+    print(f"{a}\n  {short(nodes[a]['title'])}")
+    for _parent, direction, kind, target in chain:
+        print(f"    {direction}{kind}")
+        print(f"{target}\n  {short(nodes[target]['title'])}")
+    print(f"\n{len(chain)} hops")
+
+
+def cmd_lint(nodes, edges, problems, registry_path, only_files, as_json):
+    findings = list(problems)
+    if registry_path and os.path.isfile(registry_path):
+        with open(registry_path, encoding="utf-8") as f:
+            registry_text = f.read()
+        registry = set()
+        for pat in TAG_REGISTRY_RES:
+            registry.update(pat.findall(registry_text))
+        for nid, info in nodes.items():
+            unknown = info["tags"] - registry
+            if unknown:
+                findings.append((nid, "unknown-tag",
+                                 "not in registry: " + " ".join(sorted(unknown))))
+    if only_files:
+        keys = {os.path.basename(f) for f in only_files}
+        findings = [f for f in findings if os.path.basename(f[0]) in keys]
+    findings.sort()
+    if as_json:
+        print(json.dumps([{"id": i, "check": c, "detail": d} for i, c, d in findings],
+                         ensure_ascii=False, indent=1))
+    else:
+        for nid, check, detail in findings:
+            print(f"{check:>14}  {nid}\n                {detail}")
+        print(f"\n{len(findings)} finding(s)")
+    sys.exit(1 if findings else 0)
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--root", default=".claude/knowledge/entries",
+                   help="entries root directory (default: %(default)s)")
+    p.add_argument("--json", action="store_true", help="machine-readable output")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("stats")
+    n = sub.add_parser("neighborhood")
+    n.add_argument("entry")
+    n.add_argument("--depth", type=int, default=1)
+    pa = sub.add_parser("path")
+    pa.add_argument("a")
+    pa.add_argument("b")
+    li = sub.add_parser("lint")
+    li.add_argument("files", nargs="*",
+                    help="limit findings to these files (e.g. staged entries)")
+    li.add_argument("--registry", default=None,
+                    help="tag registry markdown (default: <root>/../CLAUDE.md)")
+    args = p.parse_args()
+
+    nodes, edges, problems = load_graph(args.root)
+    if not nodes:
+        sys.exit(f"error: no entries under {args.root}")
+
+    if args.cmd == "stats":
+        cmd_stats(nodes, edges, args.json)
+    elif args.cmd == "neighborhood":
+        cmd_neighborhood(nodes, edges, resolve_entry(nodes, args.entry), args.depth, args.json)
+    elif args.cmd == "path":
+        cmd_path(nodes, edges, resolve_entry(nodes, args.a), resolve_entry(nodes, args.b), args.json)
+    elif args.cmd == "lint":
+        registry = args.registry or os.path.join(args.root, "..", "CLAUDE.md")
+        cmd_lint(nodes, edges, problems, registry, args.files, args.json)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/recall-knowledge/SKILL.md
+++ b/skills/recall-knowledge/SKILL.md
@@ -24,6 +24,13 @@ cross-language wording (e.g. Japanese ↔ English identifiers) that literal keyw
 - NOT for per-prompt automatic injection — that stays ripgrep via the existing
   `userpromptsubmit_knowledge_search.sh` hook (instant, no model load)
 
+## Structure First for Multi-Hop Questions
+When the recall looks like it needs several hops — tracing how a decision evolved,
+asking how two topics connect, or mapping everything around an entry — do NOT chain
+search → read → follow links → read again. Query the link graph first
+(`kb_graph.py neighborhood` / `path`), pick the endpoints from the structure
+(IDs + titles only), and Read just those entries. Details in the procedure file.
+
 ## Execution (run directly — do NOT delegate to a subagent)
 
 IMPORTANT: hybrid search executes code (`uv run` a Python script). Subagents run in a sandbox
@@ -38,6 +45,7 @@ Paths:
 - Knowledge base: {project_root}/.claude/knowledge/
 - Search script:  {plugin_root}/scripts/kb_search.py
 - Index builder:  {plugin_root}/scripts/kb_index.py (only to advise building the index)
+- Graph CLI:      {plugin_root}/scripts/kb_graph.py (pure stdlib — needs neither uv nor the index)
 
 IMPORTANT: The procedure / script paths use the plugin's base directory, NOT the project
 directory. Read the "Base directory for this skill" line from the skill loading message to

--- a/skills/recall-knowledge/procedure.md
+++ b/skills/recall-knowledge/procedure.md
@@ -12,11 +12,15 @@ subagents are sandboxed and cannot run `uv` / Python). On-demand only.
 - `SEARCH`  = `{plugin_root}/scripts/kb_search.py`
 - `INDEX`   = `{project_root}/.claude/knowledge/.index/kb.db`
 - `BUILDER` = `{plugin_root}/scripts/kb_index.py` (referenced only when advising a build)
+- `GRAPH`   = `{plugin_root}/scripts/kb_graph.py` (pure stdlib — works without `uv` or `INDEX`)
 
 ## Step 2. Decide hybrid vs fallback
 Hybrid is available **iff** `uv` is on `PATH` **and** `INDEX` exists.
 - Both present → Step 3a (hybrid).
 - Otherwise → Step 3b (ripgrep fallback).
+
+Either way, if the recall looks **multi-hop** (see Step 3c), pull graph structure
+first and use search only to find the starting entry.
 
 ## Step 3a. Hybrid search (preferred)
 Run from Bash (main agent):
@@ -47,6 +51,27 @@ Notes:
   uv run "{plugin_root}/scripts/kb_index.py" "{KB_ROOT}"
   ```
   (first run downloads ~220 MB model; under corporate TLS see `docs/hybrid-search.md`)
+
+## Step 3c. Structure first when the recall is multi-hop
+Signals that a flat top-N search will NOT answer in one shot:
+- Tracing lineage: "how did this decision evolve", "what led to X"
+- Connecting topics: "how are X and Y related", "is there prior art linking X to Y"
+- Mapping an area: "everything we know around X", before refactoring a topic cluster
+
+For those, do **not** loop search → Read → follow `see:` → Read again (each hop reads a
+full body just to decide where to go next). Instead:
+
+```bash
+python3 "{plugin_root}/scripts/kb_graph.py" --root "{KB_ROOT}" neighborhood <entry> --depth 2
+python3 "{plugin_root}/scripts/kb_graph.py" --root "{KB_ROOT}" path <entryA> <entryB>
+```
+
+- Entries are addressed by unique filename substring; use Step 3a/3b (or `stats` for
+  hubs) only to identify the starting entry when it is not already known.
+- Output is structure only — IDs, titles, edge kinds, never body text — so it is cheap
+  to keep in context. Plan the route from it, then **Read only the endpoint entries**
+  (typically 1–3) that actually answer the question.
+- Runs with plain `python3` (stdlib only): available even when hybrid search is not.
 
 ## Step 4. Present results
 - Show the ranked entries as printed by kb_search.py: score, title, relpath, tags, snippet.

--- a/skills/review-knowledge/SKILL.md
+++ b/skills/review-knowledge/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   missing links between related entries, and generate topic summaries. Supports the "internalization"
   phase of knowledge management by surfacing knowledge for periodic review and reflection.
 license: MIT
-allowed-tools: Read, Agent
+allowed-tools: Read, Agent, Bash
 ---
 
 # Review Knowledge
@@ -28,7 +28,19 @@ Delegate the review work to a Sonnet subagent to minimize main context consumpti
    - `topic:<keyword>` → `topic` with the specified keyword
    - `fix` → `fix`
 2. Determine the knowledge base path (default: `.claude/knowledge/entries/`)
-3. Spawn a subagent with the following configuration:
+3. Precompute deterministic graph facts from the MAIN agent's Bash (subagents run in a
+   sandbox that blocks code execution, so these must run here):
+
+```bash
+python3 "{plugin_root}/scripts/kb_graph.py" --root .claude/knowledge/entries stats
+python3 "{plugin_root}/scripts/kb_graph.py" --root .claude/knowledge/entries lint --json
+```
+
+   Notes: pure stdlib, ~1s, no index needed. `lint` exiting 1 just means it found
+   findings — capture stdout either way. If `python3` is unavailable or the commands
+   fail, set both outputs to `(unavailable)` and continue; the subagent then derives
+   everything by reading files as before.
+4. Spawn a subagent with the following configuration:
 
 ```
 Agent(
@@ -48,6 +60,12 @@ Agent(
     ### current_date
     {current_date}
 
+    ### graph_stats (deterministic, precomputed by kb_graph.py)
+    {graph_stats}
+
+    ### graph_lint (deterministic, precomputed by kb_graph.py)
+    {graph_lint}
+
     ## Instructions
     1. Read the procedure file at: {plugin_root}/skills/review-knowledge/procedure.md
     2. Follow the procedure step by step for the specified mode
@@ -60,9 +78,10 @@ Replace the placeholders:
 - `{mode}` — review mode: `health`, `topic`, or `fix`
 - `{topic_keyword}` — keyword or tag for topic mode (empty for other modes)
 - `{current_date}` — today's date in YYYY-MM-DD format (needed for stale entry detection)
+- `{graph_stats}` / `{graph_lint}` — stdout captured in step 3 (`(unavailable)` on failure)
 - `{plugin_root}` — the plugin's installation path (shown in the skill loading message as "Base directory for this skill")
 - `{project_root}` — the project working directory
 
-4. Report the subagent's result to the user
+5. Report the subagent's result to the user
 
 IMPORTANT: The procedure file path uses the plugin's base directory, NOT the project directory. Read the "Base directory for this skill" line from the skill loading message to determine the correct path.

--- a/skills/review-knowledge/procedure.md
+++ b/skills/review-knowledge/procedure.md
@@ -9,6 +9,23 @@ Maintain knowledge base health and surface entries for review, helping the user 
 - `.claude/knowledge/entries/` directory exists with entries created by `record-knowledge`
 - `.claude/knowledge/CLAUDE.md` tag registry exists
 
+## Precomputed Graph Facts (input)
+
+The input may contain `graph_stats` and `graph_lint` sections — deterministic output of
+`scripts/kb_graph.py` (link graph + lint), precomputed by the main agent. When present
+(not `(unavailable)`), treat them as ground truth instead of re-deriving by hand:
+
+- `graph_stats` covers orphan detection (b), and the connectivity part of the summary
+  statistics (e): hubs, edge counts, connected components
+- `graph_lint` covers broken see links (g), broken file references (h — `broken-link`
+  and `out-of-tree` findings), unregistered tags (part of d), plus `self-link`,
+  `duplicate-link`, `missing-title`, and `filename` findings
+
+Spend the saved effort on the judgment sections the script cannot do: staleness (a),
+missing connections (c), synthesis candidates (j), overviews (l), topic summaries.
+When the sections are absent or `(unavailable)`, derive everything by reading files
+as described below.
+
 ## Review Modes
 
 Execute the mode specified in the input. If no mode is given, run **health check**.

--- a/tests/test_kb_graph.py
+++ b/tests/test_kb_graph.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""Dependency-free self-tests for scripts/kb_graph.py.
+
+Run: python3 tests/test_kb_graph.py   (exit 0 = all pass)
+
+Builds a synthetic knowledge base in a temp dir shaped like a real project
+(<repo>/.claude/knowledge/entries/YYYY/MM/...) so link resolution and the
+broken-link vs out-of-tree distinction behave as in production.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+SCRIPTS = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scripts")
+sys.path.insert(0, SCRIPTS)
+import kb_graph  # noqa: E402
+
+KB_GRAPH = os.path.join(SCRIPTS, "kb_graph.py")
+
+ENTRY_A = "2026/07/20260701-100000-alice-topic-a.md"
+ENTRY_B = "2026/07/20260701-110000-alice-topic-b.md"
+ENTRY_C = "2026/07/20260702-090000-alice-orphan-c.md"
+ENTRY_D = "2026/07/notes.md"
+
+
+def make_kb(base):
+    """Create <base>/repo/.claude/knowledge/{entries,CLAUDE.md}; return entries root."""
+    root = os.path.join(base, "repo", ".claude", "knowledge", "entries")
+    os.makedirs(os.path.join(root, "2026", "07"))
+
+    def write(relpath, text):
+        path = os.path.join(root, relpath)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(text)
+
+    write(ENTRY_A, f"""---
+title: Topic A
+created: 2026-07-01
+status: active
+tags: "#pitfall"
+---
+
+Body A.
+
+- see: [Topic B]({ENTRY_B}) — forward link
+- see: [Topic B]({ENTRY_B}) — duplicate on purpose
+- ref: [external](https://example.com/doc) — ignored
+- ref: [in-repo missing](../../../rules/missing.md) — broken inside repo
+- ref: [outside repo](../../../../../../outside.txt) — escapes the repo
+""")
+    write(ENTRY_B, f"""---
+title: Topic B
+created: 2026-07-01
+status: active
+tags: "#pitfall #mystery"
+---
+
+Body B.
+
+- see: [Topic A]({ENTRY_A}) — back link
+- see: [Topic B]({ENTRY_B}) — self link on purpose
+""")
+    write(ENTRY_C, """---
+title: Orphan C
+created: 2026-07-02
+status: active
+tags: "#docker"
+---
+
+No links at all.
+""")
+    write(ENTRY_D, "No frontmatter, bad filename.\n")
+
+    registry = os.path.join(base, "repo", ".claude", "knowledge", "CLAUDE.md")
+    with open(registry, "w", encoding="utf-8") as f:
+        # Both registry line forms must be recognised.
+        f.write("# Knowledge Base\n\n## Tag Registry\n\n"
+                "- #pitfall — recurring traps (2)\n"
+                "`#docker`\n")
+    return root
+
+
+def run_cli(root, *argv):
+    return subprocess.run(
+        [sys.executable, KB_GRAPH, "--root", root, *argv],
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def test_load_graph_nodes_edges_and_problems():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        nodes, edges, problems = kb_graph.load_graph(root)
+        assert set(nodes) == {ENTRY_A, ENTRY_B, ENTRY_C, ENTRY_D}, nodes.keys()
+        # A→B and B→A survive; duplicate and self link are dropped as findings.
+        assert {(s, d) for s, d, _k, _r in edges} == {(ENTRY_A, ENTRY_B), (ENTRY_B, ENTRY_A)}, edges
+        checks = {(nid, check) for nid, check, _ in problems}
+        assert (ENTRY_A, "duplicate-link") in checks, checks
+        assert (ENTRY_A, "broken-link") in checks, checks
+        assert (ENTRY_A, "out-of-tree") in checks, checks
+        assert (ENTRY_B, "self-link") in checks, checks
+        assert (ENTRY_D, "missing-title") in checks, checks
+        assert (ENTRY_D, "filename") in checks, checks
+        # https ref must produce neither an edge nor a finding.
+        assert not any("example.com" in d for _n, _c, d in problems), problems
+
+
+def test_components_and_orphans():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        nodes, edges, _problems = kb_graph.load_graph(root)
+        comps = kb_graph.components(nodes, edges)
+        assert [len(c) for c in comps] == [2, 1, 1], [len(c) for c in comps]
+        assert set(comps[0]) == {ENTRY_A, ENTRY_B}, comps[0]
+
+
+def test_resolve_entry():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        nodes, _edges, _problems = kb_graph.load_graph(root)
+        assert kb_graph.resolve_entry(nodes, "topic-a") == ENTRY_A
+        assert kb_graph.resolve_entry(nodes, ENTRY_B) == ENTRY_B
+        for bad in ("topic", "no-such-entry"):  # ambiguous / no match
+            try:
+                kb_graph.resolve_entry(nodes, bad)
+                raise AssertionError(f"resolve_entry('{bad}') should exit")
+            except SystemExit as e:
+                assert "error" in str(e.code), e.code
+
+
+def test_cli_stats_json():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        res = run_cli(root, "--json", "stats")
+        assert res.returncode == 0, res.stderr
+        data = json.loads(res.stdout)
+        assert data["nodes"] == 4 and data["edges"] == 2, data
+        assert data["orphans"] == [ENTRY_C, ENTRY_D], data["orphans"]
+        assert data["components"] == [2, 1, 1], data["components"]
+
+
+def test_cli_neighborhood_and_path_json():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        res = run_cli(root, "--json", "neighborhood", "topic-a", "--depth", "1")
+        assert res.returncode == 0, res.stderr
+        data = json.loads(res.stdout)
+        assert [n["id"] for n in data["neighbors"]] == [ENTRY_B], data
+        # Structure only — no body text may leak into the output.
+        assert "Body" not in res.stdout, res.stdout
+
+        res = run_cli(root, "--json", "path", "topic-a", "topic-b")
+        assert res.returncode == 0, res.stderr
+        assert json.loads(res.stdout)["hops"] == 1, res.stdout
+
+        res = run_cli(root, "path", "topic-a", "orphan-c")
+        assert res.returncode == 1, "disconnected pair must exit 1"
+
+
+def test_cli_lint_findings_and_scoping():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        res = run_cli(root, "--json", "lint")
+        assert res.returncode == 1, "findings must exit 1"
+        findings = json.loads(res.stdout)
+        by_check = {}
+        for f in findings:
+            by_check.setdefault(f["check"], []).append(f["id"])
+        # #pitfall (list form) and #docker (backtick form) are registered;
+        # only #mystery is unknown.
+        assert by_check.get("unknown-tag") == [ENTRY_B], by_check
+        assert "#mystery" in [f["detail"] for f in findings if f["check"] == "unknown-tag"][0]
+        # Scoping to one file keeps only its findings (pre-commit usage).
+        res = run_cli(root, "--json", "lint", os.path.join(root, ENTRY_D))
+        scoped = json.loads(res.stdout)
+        assert {f["id"] for f in scoped} == {ENTRY_D}, scoped
+
+
+def test_cli_lint_clean_exits_zero():
+    with tempfile.TemporaryDirectory() as base:
+        root = os.path.join(base, "repo", ".claude", "knowledge", "entries")
+        os.makedirs(root)
+        with open(os.path.join(root, "20260701-100000-alice-clean.md"), "w",
+                  encoding="utf-8") as f:
+            f.write('---\ntitle: Clean\ntags: "#pitfall"\n---\n\nNothing wrong here.\n')
+        with open(os.path.join(base, "repo", ".claude", "knowledge", "CLAUDE.md"), "w",
+                  encoding="utf-8") as f:
+            f.write("- #pitfall — recurring traps (1)\n")
+        res = run_cli(root, "lint")
+        assert res.returncode == 0, (res.stdout, res.stderr)
+
+
+def main() -> int:
+    tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"  ok  {t.__name__}")
+        except AssertionError as e:
+            failed += 1
+            print(f"FAIL  {t.__name__}: {e}")
+    print(f"\n{len(tests) - failed}/{len(tests)} passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds `scripts/kb_graph.py`, a link-graph CLI over the knowledge base, and wires it into the `recall-knowledge` and `review-knowledge` skills.

The graph is built **on demand** from `- see:` / `- ref:` links (no persisted index to go stale; ~1s for a few hundred entries), and query output is **structure only** — entry IDs, titles, edge kinds, never body text — so results stay cheap to keep in a model context. Pure stdlib: runs with plain `python3`, no `uv`, no vector index, no network.

### Subcommands

| Command | What it does |
|---------|--------------|
| `stats` | Graph overview: hubs, orphans, connected components |
| `neighborhood <entry>` | BFS around an entry (`--depth N`) |
| `path <a> <b>` | Shortest link path between two entries |
| `lint [files...]` | Deterministic checks; exit 1 on findings (pre-commit friendly) |

`lint` covers broken links (split into in-repo `broken-link` vs checkout-dependent `out-of-tree`), self/duplicate links, missing titles, filename format, and tags missing from the registry (both registry line forms: `- #tag — description (count)` and backtick-wrapped).

### Skill wiring

- **recall-knowledge** — multi-hop recalls (tracing how a decision evolved, connecting two topics, mapping an area) now pull graph structure first via `neighborhood` / `path` and Read only the endpoint entries, instead of chaining search → read → follow links → read again.
- **review-knowledge** — the main agent precomputes `stats` + `lint` (deterministic, ~1s) and passes the output to the review subagent, which spends its effort on judgment work (staleness, missing connections, synthesis). The skill now allows Bash for that precompute step, with graceful fallback to the previous read-everything behaviour.

### Design constraints (deliberate)

- Graph is built per query — no `graph.json`-style cache, so freshness issues cannot arise.
- `lint` is deterministic only: no model calls, ever, so it can gate commits. Judgment work (e.g. staleness) stays in `/review-knowledge`.
- Query output never includes body text — the whole point is replacing "read a body to decide where to navigate next" with a structural query.

### Known limitations

- Bidirectional links (A⇄B) show only the direction discovered first in traversal output.
- `out-of-tree` link resolution depends on checkout location (worktrees / other machines) — mitigated by reporting it as its own category, separate from `broken-link`.
- No community detection yet; connected components stand in for it.

## Testing

- `tests/test_kb_graph.py` (new, dependency-free like the existing tests): 7/7 pass — link resolution, broken-link vs out-of-tree classification, components, CLI JSON output, lint exit codes, file scoping, both tag-registry forms.
- `tests/test_policy.py`, `tests/test_autocommit.py`: still pass.
- `lint-skills.sh`: 24 checks, 0 warnings, 0 errors.
- Smoke-tested read-only against a real knowledge base (237 entries, 1,226 links): structure output matches the values measured during prototyping.

## Notes

- Version bump and release intentionally left out — `[Unreleased]` section added to the CHANGELOG; version/release to be decided separately.
