### PR TITLE
docs: restructure README as entry point and document kb_graph (v1.15.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,30 +4,31 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![Claude Code plugin](https://img.shields.io/badge/Claude%20Code-plugin-7c5cff)
 
-Claude Code starts every session with a blank slate. The quirk you debugged yesterday,
-the plan you were halfway through — all gone when the session ends. ccmemo saves that
-knowledge and progress as Markdown files in your repository, so the next session picks
-up where you left off.
+Claude Code starts every session with a blank slate — ccmemo saves knowledge and
+plans as plain Markdown in your repository, so the next session (or a teammate's)
+picks up where you left off.
 
-## What It Does
+- **`/record-knowledge`** — save quirks, pitfalls, and decisions as tagged Markdown
+  entries under `.claude/knowledge/entries/`
+- **`/recall-knowledge`** — hybrid semantic search over entries (ripgrep + local
+  vector embeddings + the `see:`-link graph); falls back to plain ripgrep when the
+  index is absent
+- **`/review-knowledge`** — knowledge-base health checks: stale entries, orphans,
+  missing links, tag issues
+- **`/plan-task`** — persist multi-step plans and progress across sessions,
+  Git-tracked or issue-centric
+- **Link-graph CLI** — `scripts/kb_graph.py` answers structural questions (hubs,
+  neighborhoods, shortest link paths) and lints link integrity; pure stdlib,
+  pre-commit friendly
+- **Context Guard** — hooks that defend against knowledge loss when the context
+  is compacted
+- **Plain Markdown in git** — entries follow the same branch/merge/review workflow
+  as your code and render cleanly on GitHub/GitLab
 
-ccmemo adds four slash commands that persist knowledge and plans as plain Markdown in
-`.claude/`:
-
-| Command | What it does | More |
-|---------|--------------|------|
-| `/record-knowledge` | Save a quirk, pitfall, or decision as a tagged entry | [Example](#example) |
-| `/recall-knowledge` | Hybrid semantic search across entries (synonyms, cross-language) | [docs/hybrid-search.md](docs/hybrid-search.md) |
-| `/review-knowledge` | Keep the knowledge base healthy — stale/orphan entries, missing links, tag issues | [Reviewing](#reviewing-knowledge) |
-| `/plan-task` | Persist multi-step plans and progress across sessions | [Plan & task](#plan--task-management) |
-
-Claude Code invokes these automatically when relevant; you can also trigger any of them
-by name.
+Claude Code invokes the skills automatically when relevant; you can also trigger
+any of them by name.
 
 ## Quick start
-
-Up and running in three steps. The plugin is the recommended path — skills and hooks
-activate the moment it's installed.
 
 **1. Install the plugin** (in Claude Code):
 
@@ -36,54 +37,25 @@ activate the moment it's installed.
 /plugin install ccmemo@levnas-plugins
 ```
 
-That alone makes `/record-knowledge`, `/plan-task`, `/review-knowledge`, and
-`/recall-knowledge` available and wires up the [Context Guard](docs/architecture.md#context-guard-since-v110) hooks.
+That alone makes the four skills available and wires up the
+[Context Guard](docs/architecture.md#context-guard-since-v110) hooks.
 
-**2. Scaffold the starter config** into your project — a tag registry for knowledge and
-an index for tasks. Easiest is to just ask Claude Code:
+**2. Scaffold the starter config** — a tag registry for knowledge and an index
+for tasks. Easiest is to just ask Claude Code:
 
 > Scaffold ccmemo's knowledge and tasks templates into `.claude/`.
 
-Prefer a command? From your project root:
+**3. Try it.** Run `/record-knowledge` and describe something worth remembering —
+Claude writes a Markdown entry under `.claude/knowledge/entries/`. Commit it, and
+your next session (or a teammate's) finds it automatically.
 
-```bash
-tpl=$(find ~/.claude/plugins/cache -type d -path '*ccmemo*/templates' | sort | tail -1)
-cp -r "$tpl/knowledge" .claude/knowledge
-cp -r "$tpl/tasks"     .claude/tasks
-```
+Installing without the marketplace and scaffolding by shell command are covered
+in [docs/usage.md](docs/usage.md). Semantic search via `/recall-knowledge` is
+opt-in (one-time index build) — see [docs/hybrid-search.md](docs/hybrid-search.md).
 
-**3. Try it.** Run `/record-knowledge` and describe something worth remembering — Claude
-writes a Markdown entry under `.claude/knowledge/entries/`. Commit it, and your next
-session (or a teammate's) finds it automatically.
+## Examples
 
-> Semantic search via `/recall-knowledge` is opt-in (one-time index build) — see
-> [docs/hybrid-search.md](docs/hybrid-search.md).
-
-### Without the marketplace
-
-Copy the skills and templates straight from the repo:
-
-```bash
-git clone --depth 1 https://github.com/LevNas/ccmemo /tmp/ccmemo
-cp -r /tmp/ccmemo/skills/*            .claude/skills/      # the four skills
-cp -r /tmp/ccmemo/templates/knowledge .claude/knowledge
-cp -r /tmp/ccmemo/templates/tasks     .claude/tasks
-rm -rf /tmp/ccmemo
-```
-
-Your project ends up with:
-
-```
-your-project/.claude/
-├── skills/{record-knowledge,plan-task,review-knowledge,recall-knowledge}/SKILL.md
-├── knowledge/{CLAUDE.md,entries/}
-└── tasks/{CLAUDE.md,readme.md}
-```
-
-Hooks (Context Guard) are wired through the plugin; with a manual copy, add the
-`hooks/hooks.json` entries yourself if you want them.
-
-## Example
+### A recorded entry
 
 `/record-knowledge` creates an entry like
 `.claude/knowledge/entries/20260302-143052-alice-docker-compose-port-conflict.md`:
@@ -104,98 +76,33 @@ Use `ports: ["8080:80"]` or stop host nginx first.
 - see: [Nginx reverse proxy setup](nginx-reverse-proxy.md) — related configuration
 ```
 
-See [docs/examples.md](docs/examples.md) for personal and team workflow walkthroughs.
+Personal and team workflow walkthroughs: [docs/examples.md](docs/examples.md).
 
-## Usage
+### Querying the link graph
 
-### Searching entries
-
-Quick keyword/filename lookups need no setup:
-
-```bash
-fd -e md . .claude/knowledge/entries/ | fzf   # fuzzy search by filename
-rg '#pitfall' .claude/knowledge/entries/      # search by tag
-rg '^title:' .claude/knowledge/entries/       # list all titles
-```
-
-For meaning-based search (synonyms, or a Japanese query against English identifiers),
-`/recall-knowledge` runs hybrid semantic search — ripgrep + local vector embeddings +
-the `see:`-link graph — and falls back to ripgrep when the index is absent. Setup:
-[docs/hybrid-search.md](docs/hybrid-search.md).
-
-For multi-hop questions ("how did this decision evolve", "how do X and Y connect"),
-`scripts/kb_graph.py` queries the `see:`-link graph directly — `stats`, `neighborhood`,
-`path`, and a deterministic `lint` (pre-commit friendly). Pure stdlib, no index: the
-graph is built on demand from the entries, and output is structure only (IDs, titles,
-edge kinds — no body text), so you read only the entries the structure points at.
+Multi-hop questions ("how did this decision evolve", "how do X and Y connect")
+go structure-first through the `see:`-link graph — pure stdlib, no index:
 
 ```bash
 python3 scripts/kb_graph.py stats                    # hubs, orphans, components
-python3 scripts/kb_graph.py neighborhood <entry> --depth 2
 python3 scripts/kb_graph.py path <entry-a> <entry-b> # shortest link path
-python3 scripts/kb_graph.py lint                     # exit 1 on findings
 ```
 
-### Reviewing knowledge
-
-`/review-knowledge` keeps the base healthy in three modes:
-
-- **Health check** (default) — reports stale entries (>90 days), orphans (no `see:`
-  links), missing connections, tag issues, and summary stats
-- **Topic review** (`topic:<keyword>`) — summarizes a topic and asks reflective
-  questions to verify accuracy
-- **Fix mode** (`fix`) — interactively adds missing links and registers tags
-
-### Plan & task management
-
-`/plan-task` persists multi-step plans in `.claude/tasks/`. Two modes:
-
-- **Git-tracked** (default) — plans (`plan-v1.md`, `todo.md`, `readme.md`) are committed
-  and become the shared source of truth. Progress moves `[ ]` → `[~]` → `[x]`; plan
-  revisions are kept as `plan-v2.md`, etc. Each task dir also holds `context-*.md` files
-  that capture detailed working context (see [Context Guard](docs/architecture.md#context-guard-since-v110)).
-- **Issue-centric** — gitignore `.claude/tasks/` and treat your issue tracker (GitHub,
-  GitLab, Jira) as the source of truth; `.claude/tasks/` becomes a per-session
-  scratchpad. Session start checks assigned issues instead of `readme.md`.
-
-### Wiring into CLAUDE.md
-
-Add a lookup section to your project's `CLAUDE.md` so Claude checks relevant entries
-before starting work. Patterns and examples: [docs/claude-md-examples.md](docs/claude-md-examples.md).
-
-## Customization
-
-- **Tags** — maintain a registry in `.claude/knowledge/CLAUDE.md` (lowercase
-  kebab-case, `#` prefix). Claude checks it before creating new tags.
-- **Author** — the entry `author` field defaults to `@<username>`; set it to your Git
-  hosting username.
-- **Workflow** — edit any `skills/*/SKILL.md` to add project-specific conventions
-  (tag categories, issue-tracker comment formats, plan templates).
-- **Auto-commit (opt-in, off by default)** — set `CCMEMO_AUTOCOMMIT=1` and a
-  safety-net hook commits *only* `.claude/knowledge/` and `.claude/tasks/` changes
-  at session end (`SessionEnd`) and before compaction (`PreCompact`). It never runs
-  `git add -A`, **never pushes**, and a leak-scan gate blocks commits containing
-  leak-prone shapes (set `CCMEMO_AUTOCOMMIT_ON_LEAK=warn` to commit with a warning
-  instead). It complements — does not replace — your manual end-of-session commit,
-  so it is a no-op when you have already committed.
-
-## Why Use It in a Git Repository
-
-Everything is plain Markdown in your repo, so it follows the same branch/merge/review
-workflow as your code:
-
-- **Team sharing** — a pitfall one person finds on Monday is available to everyone
-  (and every Claude Code session) on Tuesday.
-- **Session continuity** — plans and knowledge survive across sessions; no
-  re-explaining context or re-discovering the same issues.
-- **Browsable** — files render cleanly in GitHub and GitLab with no special tooling.
+All subcommands and the pre-commit lint: [docs/link-graph.md](docs/link-graph.md).
 
 ## Documentation
 
-- [docs/architecture.md](docs/architecture.md) — subagent delegation, Context Guard, internals
+- [docs/usage.md](docs/usage.md) — day-to-day usage: searching entries, reviewing
+  the base, plans & tasks, customization, manual install
+- [docs/hybrid-search.md](docs/hybrid-search.md) — semantic search setup &
+  verification (incl. corporate TLS and NixOS)
+- [docs/link-graph.md](docs/link-graph.md) — the link-graph CLI:
+  `stats` / `neighborhood` / `path` / `lint`
+- [docs/architecture.md](docs/architecture.md) — scripts & skill wiring, subagent
+  delegation, Context Guard
 - [docs/examples.md](docs/examples.md) — personal & team workflow walkthroughs
-- [docs/hybrid-search.md](docs/hybrid-search.md) — semantic search setup & verification (incl. corporate TLS)
-- [docs/claude-md-examples.md](docs/claude-md-examples.md) — CLAUDE.md configuration
+- [docs/claude-md-examples.md](docs/claude-md-examples.md) — CLAUDE.md integration
+  patterns
 
 ## Getting help
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,6 +3,35 @@
 How ccmemo works under the hood. You don't need any of this to use the skills —
 it's here for contributors and anyone curious about the design.
 
+## Scripts & Skill Wiring
+
+Three scripts under `scripts/` back the search and review skills:
+
+| Script | Runtime | Role | Since |
+|--------|---------|------|-------|
+| `kb_index.py` | `uv` (fastembed, sqlite-vec) | Build/refresh the per-machine vector index (sha256 incremental, idempotent) | v1.11.0 |
+| `kb_search.py` | `uv` (fastembed, sqlite-vec) | Hybrid query: lexical + vector arms, RRF fusion, `see:` 1-hop expansion, frontmatter filters | v1.11.0 |
+| `kb_graph.py` | plain `python3` (pure stdlib) | On-demand link graph: `stats` / `neighborhood` / `path` / deterministic `lint` | v1.15.0 |
+
+How the skills reach them:
+
+- **`/recall-knowledge`** runs `kb_search.py` from the *main* agent's Bash
+  (subagents run in a sandbox that blocks code execution), falling back to
+  ripgrep-only when the index or its dependencies are absent, and pointing at
+  `kb_index.py` when advising an index build. Multi-hop recalls query
+  `kb_graph.py neighborhood` / `path` first and read only the endpoint
+  entries. Details: [hybrid-search.md](hybrid-search.md),
+  [link-graph.md](link-graph.md).
+- **`/review-knowledge`** has the main agent precompute `kb_graph.py stats` +
+  `lint` (deterministic, ~1s, no index needed) and pass the output to the
+  review subagent, which spends its effort on judgment work (staleness,
+  missing connections, synthesis) instead of re-deriving link facts by hand.
+  Falls back to the previous read-everything behaviour when `python3` is
+  unavailable.
+- The per-prompt `UserPromptSubmit` hook stays **ripgrep-only** (instant,
+  model-free injection) — neither the vector index nor the graph CLI is wired
+  into it.
+
 ## Subagent Delegation (since v1.8.0)
 
 Both `record-knowledge` and `plan-task` delegate their execution to a Sonnet

--- a/docs/claude-md-examples.md
+++ b/docs/claude-md-examples.md
@@ -85,6 +85,8 @@ When literal keywords miss — synonyms, or a query worded differently from the 
 (e.g. a Japanese query against English identifiers) — run the `/recall-knowledge` skill.
 It does hybrid semantic search (ripgrep + local vector embeddings + the `see:`-link graph)
 and falls back to ripgrep when the index is unavailable, so it is always safe to try.
+For multi-hop questions (how a decision evolved, how two topics connect) it queries the
+link-graph structure first and reads only the endpoint entries (see docs/link-graph.md).
 
 ### Rules
 - Only reference entries with `status: active` — ignore `deprecated` entries

--- a/docs/hybrid-search.md
+++ b/docs/hybrid-search.md
@@ -16,6 +16,11 @@ cache** — regenerable at any time and **never committed to git**.
 | `scripts/kb_search.py` | Query: lexical + vector arms, RRF fusion, `see:` 1-hop expansion, frontmatter filters |
 | `hooks/post-merge.sample` | Consumer git hook: incremental re-index after `git pull` |
 
+For structural / multi-hop queries that need no index at all — hubs, orphans,
+neighborhoods, shortest link paths, link lint — see the pure-stdlib
+`scripts/kb_graph.py` in [link-graph.md](link-graph.md); it complements the
+meaning-based retrieval described here.
+
 ## Dependencies
 
 - [`fastembed`](https://pypi.org/project/fastembed/) — local ONNX embeddings.

--- a/docs/link-graph.md
+++ b/docs/link-graph.md
@@ -1,0 +1,104 @@
+# Link-Graph CLI (`kb_graph.py`)
+
+`scripts/kb_graph.py` answers structural questions about the knowledge base —
+what connects to what, and where the link integrity is broken. Pure stdlib: it
+runs with plain `python3`, needs no `uv`, no vector index, and no network.
+
+## Design
+
+- **On-demand graph, no persisted index.** The graph is rebuilt each run from
+  the `- see:` / `- ref:` list links in the entries (~1s for a few hundred
+  entries). There is nothing to go stale and nothing to rebuild after a pull.
+- **Structure only, never body text.** Output contains entry IDs, titles, and
+  edge kinds — so results stay cheap to inject into a model context. The
+  intended flow is *structure first, bodies last*: use `neighborhood` / `path`
+  to plan where to go, then read only the endpoint entries.
+- **Deterministic lint.** `lint` makes no model calls, so it can gate commits.
+  Judgment work — staleness review, missing-connection suggestions — stays in
+  `/review-knowledge`.
+
+## Subcommands
+
+Run from the project root; the default `--root` is `.claude/knowledge/entries`.
+
+```bash
+python3 scripts/kb_graph.py stats                    # hubs, orphans, components
+python3 scripts/kb_graph.py neighborhood <entry> --depth 2
+python3 scripts/kb_graph.py path <entry-a> <entry-b> # shortest link path
+python3 scripts/kb_graph.py lint                     # exit 1 on findings
+```
+
+### `stats`
+
+Graph overview: node/edge counts by edge kind, connected components, the top
+hub entries (in/out degree), and orphans (no links in either direction).
+
+### `neighborhood <entry>`
+
+BFS around an entry up to `--depth` (default 1), listing each neighbor with
+its depth, link direction (`→` outgoing / `←` incoming), and edge kind.
+
+### `path <a> <b>`
+
+Shortest link path between two entries, treating links as bidirectional.
+Exits 1 if no path exists.
+
+### `lint [files...]`
+
+Deterministic integrity checks; exits 1 when there are findings, 0 when clean:
+
+| Check | Meaning |
+|---|---|
+| `broken-link` | `see:`/`ref:` target resolves to no file inside the repository |
+| `out-of-tree` | target escapes the repository — resolves differently per checkout or machine |
+| `self-link` | entry links to itself |
+| `duplicate-link` | same link listed more than once in an entry |
+| `missing-title` | no `title:` in the frontmatter |
+| `filename` | filename does not match `<date>-<time>-...-<slug>.md` |
+| `unknown-tag` | tag not in the registry (default: `<root>/../CLAUDE.md`, override with `--registry`) |
+
+Passing file arguments limits the *reported* findings to those files (the
+graph is still built from all entries), which is exactly what a pre-commit
+hook wants:
+
+```sh
+changed=$(git diff --cached --name-only -- .claude/knowledge/entries/)
+[ -z "$changed" ] || python3 scripts/kb_graph.py lint $changed
+```
+
+## Addressing entries
+
+`neighborhood` and `path` accept an entry's path relative to the entries root,
+or any **unique filename substring** — `docker-compose` is enough if only one
+entry matches. Ambiguous queries fail with the list of candidates.
+
+## Link resolution
+
+Link targets are tried relative to the entries root first, then relative to
+the linking entry's own directory. `http(s)` targets are skipped. Links that
+leave the entries tree (e.g. into `docs/` or rules files) are existence-checked
+by `lint` but are not part of the entry graph.
+
+## Flags
+
+- `--json` — machine-readable output for every subcommand
+- `--root <dir>` — entries root (default `.claude/knowledge/entries`)
+- `--depth <n>` — BFS depth for `neighborhood` (default 1)
+- `--registry <file>` — tag registry for `lint` (default `<root>/../CLAUDE.md`)
+
+## How the skills use it
+
+- **`/recall-knowledge`** — multi-hop recalls (tracing how a decision evolved,
+  connecting two topics, mapping an area) query `neighborhood` / `path` first
+  and read only the endpoint entries, instead of chaining
+  search → read → follow links → read again.
+- **`/review-knowledge`** — the main agent precomputes `stats` + `lint` and
+  passes the output to the review subagent, which spends its effort on
+  judgment work instead of re-deriving link facts by hand.
+
+## Related
+
+- [hybrid-search.md](hybrid-search.md) — meaning-based retrieval (needs the
+  per-machine vector index); complements the graph's structure-only queries
+- [architecture.md](architecture.md) — how the three `kb_*` scripts and the
+  skills fit together

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,119 @@
+# Usage Guide
+
+Day-to-day workflows once ccmemo is installed, plus manual installation and
+customization. For the fastest install path, see the Quick start in the
+[README](../README.md).
+
+## Installing without the marketplace
+
+Copy the skills and templates straight from the repo:
+
+```bash
+git clone --depth 1 https://github.com/LevNas/ccmemo /tmp/ccmemo
+cp -r /tmp/ccmemo/skills/*            .claude/skills/      # the four skills
+cp -r /tmp/ccmemo/templates/knowledge .claude/knowledge
+cp -r /tmp/ccmemo/templates/tasks     .claude/tasks
+rm -rf /tmp/ccmemo
+```
+
+Your project ends up with:
+
+```
+your-project/.claude/
+├── skills/{record-knowledge,plan-task,review-knowledge,recall-knowledge}/SKILL.md
+├── knowledge/{CLAUDE.md,entries/}
+└── tasks/{CLAUDE.md,readme.md}
+```
+
+Hooks (Context Guard) are wired through the plugin; with a manual copy, add the
+`hooks/hooks.json` entries yourself if you want them.
+
+### Scaffolding templates by hand (plugin install)
+
+If you installed via the marketplace and prefer a shell command over asking
+Claude Code to scaffold, run from your project root:
+
+```bash
+tpl=$(find ~/.claude/plugins/cache -type d -path '*ccmemo*/templates' | sort | tail -1)
+cp -r "$tpl/knowledge" .claude/knowledge
+cp -r "$tpl/tasks"     .claude/tasks
+```
+
+## Searching entries
+
+Quick keyword/filename lookups need no setup:
+
+```bash
+fd -e md . .claude/knowledge/entries/ | fzf   # fuzzy search by filename
+rg '#pitfall' .claude/knowledge/entries/      # search by tag
+rg '^title:' .claude/knowledge/entries/       # list all titles
+```
+
+For meaning-based search (synonyms, or a Japanese query against English
+identifiers), `/recall-knowledge` runs hybrid semantic search — ripgrep +
+local vector embeddings + the `see:`-link graph — and falls back to ripgrep
+when the index is absent. Setup: [hybrid-search.md](hybrid-search.md).
+
+For multi-hop questions ("how did this decision evolve", "how do X and Y
+connect"), `scripts/kb_graph.py` queries the `see:`-link graph directly —
+pure stdlib, no index needed. Subcommands and pre-commit lint:
+[link-graph.md](link-graph.md).
+
+## Reviewing knowledge
+
+`/review-knowledge` keeps the base healthy in three modes:
+
+- **Health check** (default) — reports stale entries (>90 days), orphans (no
+  `see:` links), missing connections, tag issues, and summary stats
+- **Topic review** (`topic:<keyword>`) — summarizes a topic and asks
+  reflective questions to verify accuracy
+- **Fix mode** (`fix`) — interactively adds missing links and registers tags
+
+## Plan & task management
+
+`/plan-task` persists multi-step plans in `.claude/tasks/`. Two modes:
+
+- **Git-tracked** (default) — plans (`plan-v1.md`, `todo.md`, `readme.md`) are
+  committed and become the shared source of truth. Progress moves
+  `[ ]` → `[~]` → `[x]`; plan revisions are kept as `plan-v2.md`, etc. Each
+  task dir also holds `context-*.md` files that capture detailed working
+  context (see [Context Guard](architecture.md#context-guard-since-v110)).
+- **Issue-centric** — gitignore `.claude/tasks/` and treat your issue tracker
+  (GitHub, GitLab, Jira) as the source of truth; `.claude/tasks/` becomes a
+  per-session scratchpad. Session start checks assigned issues instead of
+  `readme.md`.
+
+## Wiring into CLAUDE.md
+
+Add a lookup section to your project's `CLAUDE.md` so Claude checks relevant
+entries before starting work. Patterns and examples:
+[claude-md-examples.md](claude-md-examples.md).
+
+## Customization
+
+- **Tags** — maintain a registry in `.claude/knowledge/CLAUDE.md` (lowercase
+  kebab-case, `#` prefix). Claude checks it before creating new tags.
+- **Author** — the entry `author` field defaults to `@<username>`; set it to
+  your Git hosting username.
+- **Workflow** — edit any `skills/*/SKILL.md` to add project-specific
+  conventions (tag categories, issue-tracker comment formats, plan templates).
+- **Auto-commit (opt-in, off by default)** — set `CCMEMO_AUTOCOMMIT=1` and a
+  safety-net hook commits *only* `.claude/knowledge/` and `.claude/tasks/`
+  changes at session end (`SessionEnd`) and before compaction (`PreCompact`).
+  It never runs `git add -A`, **never pushes**, and a leak-scan gate blocks
+  commits containing leak-prone shapes (set `CCMEMO_AUTOCOMMIT_ON_LEAK=warn`
+  to commit with a warning instead). It complements — does not replace — your
+  manual end-of-session commit, so it is a no-op when you have already
+  committed.
+
+## Why keep it in a Git repository
+
+Everything is plain Markdown in your repo, so it follows the same
+branch/merge/review workflow as your code:
+
+- **Team sharing** — a pitfall one person finds on Monday is available to
+  everyone (and every Claude Code session) on Tuesday.
+- **Session continuity** — plans and knowledge survive across sessions; no
+  re-explaining context or re-discovering the same issues.
+- **Browsable** — files render cleanly in GitHub and GitLab with no special
+  tooling.


### PR DESCRIPTION
## Summary

Brings README.md and docs/ in line with v1.15.0 (which added `scripts/kb_graph.py`), and restructures the README to act as an entry point with details split out to docs/.

### README (216 → 123 lines)
- Opens with a one-sentence value proposition, then a bold-lead feature list (four skills + link-graph CLI + Context Guard + plain-Markdown-in-git)
- Quick start reduced to the minimal copy-paste path (plugin install → scaffold → try it)
- Two short examples (a recorded entry, a link-graph query), each with a one-line link to the full doc
- Documentation section lists every docs/ file with a one-line summary
- Detailed Usage/Customization content moved out (see below); the former "Why Use It in a Git Repository" section is condensed into a feature bullet with the full version in docs/usage.md

### docs/
- **docs/link-graph.md (new)** — kb_graph.py: the four subcommands (`stats` / `neighborhood` / `path` / `lint`), the design rationale (on-demand graph, no persisted index, structure-only output), entry addressing by unique filename substring, lint checks table and pre-commit example, pure-stdlib runtime (no uv, no index, no network), and how recall-knowledge / review-knowledge use it
- **docs/usage.md (new)** — receives the former README Usage/Customization content: searching entries, reviewing knowledge, plan & task modes, CLAUDE.md wiring pointer, customization (incl. opt-in auto-commit), manual install without the marketplace, scaffolding by shell command
- **docs/architecture.md** — new "Scripts & Skill Wiring" section covering the three scripts (kb_index.py / kb_search.py / kb_graph.py), how each skill reaches them, and the per-prompt hook staying ripgrep-only
- **docs/hybrid-search.md** — cross-reference to the link-graph CLI for index-free structural queries
- **docs/claude-md-examples.md** — one-sentence freshness fix: notes that /recall-knowledge handles multi-hop questions structure-first via the link graph
- **docs/examples.md** — reviewed, still accurate, unchanged

### Out of scope
- CHANGELOG.md unchanged; docs-only, no version bump

## Notes for review
- All facts are sourced from the existing README/docs/CHANGELOG and the kb_graph.py docstring/implementation — no new claims
- Example links inside fenced sample entries (`nginx-reverse-proxy.md`, `nodejs-22-upgrade.md`) are illustrative, as before