### PR TITLE
fix(hooks): suppress SECI capture inside agent isolation worktrees

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,11 +7,5 @@
   },
   "repository": "https://github.com/LevNas/ccmemo",
   "license": "MIT",
-  "keywords": [
-    "knowledge",
-    "memory",
-    "planning",
-    "tasks",
-    "persistence"
-  ]
+  "keywords": ["knowledge", "memory", "planning", "tasks", "persistence"]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,17 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "author": {
     "name": "LevNas"
   },
   "repository": "https://github.com/LevNas/ccmemo",
   "license": "MIT",
-  "keywords": ["knowledge", "memory", "planning", "tasks", "persistence"]
+  "keywords": [
+    "knowledge",
+    "memory",
+    "planning",
+    "tasks",
+    "persistence"
+  ]
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,6 +88,13 @@ Answer "不要" to skip.
 to `.claude/context-checkpoints/` with modified file paths and user decisions extracted
 from the transcript tail.
 
+**Agent worktrees:** Stages 1 and 3 skip capture when the session runs inside a
+harness-generated agent isolation worktree (`.claude/worktrees/agent-<hex>` or
+`wf_<runId>-<n>`) — captures written there are misattributed and die with the
+worktree. Detection matches only the harness naming convention, so user-named
+worktrees keep capturing. Set `CCMEMO_CAPTURE_AGENT_WORKTREES=1` to opt out of
+the suppression.
+
 ### Checkpoint lifecycle
 
 Checkpoints saved by the PreCompact hook are consumed by `/plan-task` on the next

--- a/hooks/lib/agent_worktree.py
+++ b/hooks/lib/agent_worktree.py
@@ -1,0 +1,49 @@
+"""Detection of harness-generated agent isolation worktrees (issue #17).
+
+Claude Code runs subagents in ephemeral git worktrees under
+``.claude/worktrees/`` with deterministic basenames:
+
+- Agent tool isolation:  ``agent-<hex agentId>``
+- Workflow isolation:    ``wf_<runId>-<n>``
+
+SECI captures written inside those worktrees are misattributed to
+whatever task is active in the checked-out state and die with the
+worktree, so capture hooks skip them (default-on, no configuration).
+
+Detection is deliberately tight and fails toward capturing: only a
+basename matching the harness naming convention, directly under a
+``.claude/worktrees/`` path component, suppresses capture. A user-named
+worktree such as ``agent-foo`` keeps capturing, and if the harness ever
+renames its convention the patterns simply stop matching — behavior
+falls back to today's (no regression).
+"""
+
+import os
+import re
+
+_AGENT_RE = re.compile(r"^agent-[0-9a-f]{16,}$")
+_WORKFLOW_RE = re.compile(r"^wf_[A-Za-z0-9-]+-[0-9]+$")
+
+
+def is_agent_worktree(path: str) -> bool:
+    """Return True when *path* lies inside a harness-generated agent worktree."""
+    if not path:
+        return False
+    parts = os.path.abspath(path).split(os.sep)
+    for i in range(len(parts) - 2):
+        if parts[i] == ".claude" and parts[i + 1] == "worktrees":
+            basename = parts[i + 2]
+            if _AGENT_RE.match(basename) or _WORKFLOW_RE.match(basename):
+                return True
+    return False
+
+
+def capture_suppressed(path: str) -> bool:
+    """Return True when SECI capture should be skipped for this session.
+
+    Opt-out: ``CCMEMO_CAPTURE_AGENT_WORKTREES=1`` restores capture
+    everywhere, for users who do want captures from agent sessions.
+    """
+    if os.environ.get("CCMEMO_CAPTURE_AGENT_WORKTREES") == "1":
+        return False
+    return is_agent_worktree(path)

--- a/hooks/posttooluse_context_writer.py
+++ b/hooks/posttooluse_context_writer.py
@@ -15,6 +15,9 @@ import re
 import sys
 from datetime import datetime
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lib.agent_worktree import capture_suppressed  # noqa: E402
+
 
 def find_active_task_dir(cwd: str) -> str | None:
     """Find the first active task directory from .claude/tasks/readme.md."""
@@ -135,6 +138,11 @@ def main() -> None:
 
     tool_input = input_data.get("tool_input", {})
     cwd = input_data.get("cwd", os.getcwd())
+
+    # Skip capture inside harness-generated agent worktrees (issue #17):
+    # captures there are misattributed and die with the worktree.
+    if capture_suppressed(cwd):
+        return
 
     # Find active task
     task_dir = find_active_task_dir(cwd)

--- a/hooks/precompact_checkpoint.py
+++ b/hooks/precompact_checkpoint.py
@@ -18,6 +18,7 @@ from datetime import datetime
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from lib import autocommit  # noqa: E402
+from lib.agent_worktree import capture_suppressed  # noqa: E402
 
 
 def extract_modified_files(lines: list[str]) -> list[str]:
@@ -223,6 +224,12 @@ def main() -> None:
     session_id = input_data.get("session_id", "unknown")
     trigger = input_data.get("trigger", "auto")
     cwd = input_data.get("cwd", os.getcwd())
+
+    # Skip entirely inside harness-generated agent worktrees (issue #17):
+    # checkpoint, session_state, and the safety-net commit would all land
+    # in the ephemeral worktree / agent branch and be misattributed.
+    if capture_suppressed(cwd):
+        return
 
     # Opt-in safety-net commit of knowledge/tasks (shared with the SessionEnd
     # hook). Runs independently of whether there is a transcript to checkpoint.

--- a/tests/test_agent_worktree.py
+++ b/tests/test_agent_worktree.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Dependency-free self-tests for hooks/lib/agent_worktree (issue #17).
+
+Run: python3 tests/test_agent_worktree.py   (exit 0 = all pass)
+
+Covers the tight-match detection (suppress only harness-generated agent /
+workflow worktrees, fail toward capturing otherwise), the opt-out env var,
+and an end-to-end check that the PostToolUse context writer skips capture
+inside an agent worktree but still captures in a normal checkout.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "hooks"))
+from lib.agent_worktree import capture_suppressed, is_agent_worktree  # noqa: E402
+
+HOOK = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..", "hooks", "posttooluse_context_writer.py",
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, actual, expected) -> None:
+    if actual == expected:
+        print(f"PASS: {name}")
+    else:
+        print(f"FAIL: {name} — expected {expected!r}, got {actual!r}")
+        FAILURES.append(name)
+
+
+def make_task_tree(root: str) -> str:
+    """Create a minimal .claude/tasks tree with one active task."""
+    task_dir = os.path.join(root, ".claude", "tasks", "demo-task/")
+    os.makedirs(task_dir, exist_ok=True)
+    readme = os.path.join(root, ".claude", "tasks", "readme.md")
+    with open(readme, "w", encoding="utf-8") as f:
+        f.write("# Task Index\n\n## Active\n\n| Directory |\n|---|\n| `demo-task/` |\n")
+    return os.path.join(root, ".claude", "tasks", "demo-task")
+
+
+def run_hook(cwd_path: str) -> None:
+    # file_path must not start with /tmp (the writer skips temp paths);
+    # a synthetic path is fine — only cwd decides where captures land.
+    payload = json.dumps({
+        "tool_name": "Write",
+        "tool_input": {"file_path": "/home/user/proj/x.py"},
+        "cwd": cwd_path,
+    })
+    subprocess.run(
+        [sys.executable, HOOK],
+        input=payload, capture_output=True, text=True, check=True,
+    )
+
+
+def count_captures(task_dir: str) -> int:
+    return len([f for f in os.listdir(task_dir) if f.startswith("context-")])
+
+
+def main() -> None:
+    repo = "/home/user/repo"
+    wt = repo + "/.claude/worktrees"
+
+    # --- Harness-generated worktrees: suppressed -------------------------
+    check("agent worktree root",
+          is_agent_worktree(f"{wt}/agent-a18749543825882f6"), True)
+    check("agent worktree subdir",
+          is_agent_worktree(f"{wt}/agent-a18749543825882f6/src/deep"), True)
+    check("workflow worktree",
+          is_agent_worktree(f"{wt}/wf_run-abc123-0"), True)
+    check("workflow worktree subdir",
+          is_agent_worktree(f"{wt}/wf_x9y-12/pkg"), True)
+
+    # --- Fail-safe toward capturing ---------------------------------------
+    check("user-named agent-foo keeps capturing",
+          is_agent_worktree(f"{wt}/agent-foo"), False)
+    check("short hex id keeps capturing",
+          is_agent_worktree(f"{wt}/agent-abc123"), False)
+    check("uppercase hex rejected (not harness convention)",
+          is_agent_worktree(f"{wt}/agent-A18749543825882F6"), False)
+    check("wf name without trailing index keeps capturing",
+          is_agent_worktree(f"{wt}/wf_run-abc"), False)
+    check("plain checkout",
+          is_agent_worktree(repo + "/src"), False)
+    check("named session worktree",
+          is_agent_worktree(f"{wt}/my-feature"), False)
+    check("worktrees dir not under .claude",
+          is_agent_worktree("/home/user/worktrees/agent-a18749543825882f6"), False)
+    check("empty path", is_agent_worktree(""), False)
+
+    # --- Opt-out env var ---------------------------------------------------
+    os.environ["CCMEMO_CAPTURE_AGENT_WORKTREES"] = "1"
+    check("opt-out env restores capture",
+          capture_suppressed(f"{wt}/agent-a18749543825882f6"), False)
+    os.environ.pop("CCMEMO_CAPTURE_AGENT_WORKTREES")
+    check("default: agent worktree suppressed",
+          capture_suppressed(f"{wt}/agent-a18749543825882f6"), True)
+    check("default: normal path not suppressed",
+          capture_suppressed(repo), False)
+
+    # --- End-to-end: context writer ----------------------------------------
+    tmp = tempfile.mkdtemp(prefix="ccmemo-i17-")
+    try:
+        # Normal checkout: capture IS written
+        normal = os.path.join(tmp, "repo")
+        task_dir = make_task_tree(normal)
+        run_hook(normal)
+        check("e2e: normal checkout captures", count_captures(task_dir) > 0, True)
+
+        # Agent worktree: capture is skipped
+        agent_wt = os.path.join(
+            tmp, "repo", ".claude", "worktrees", "agent-a18749543825882f6"
+        )
+        agent_task_dir = make_task_tree(agent_wt)
+        run_hook(agent_wt)
+        check("e2e: agent worktree suppressed", count_captures(agent_task_dir), 0)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print("----")
+    if FAILURES:
+        print(f"{len(FAILURES)} failure(s)")
+        sys.exit(1)
+    print("all tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #17.

## Summary

SECI capture hooks now skip harness-generated agent isolation worktrees, where captures are misattributed and die with the worktree.

- **`hooks/lib/agent_worktree.py`** — tight-match detection: suppress only when a path component chain `.claude/worktrees/<basename>` has a basename matching `agent-[0-9a-f]{16,}` or `wf_[A-Za-z0-9-]+-[0-9]+`. Fail-safe toward capturing: user-named worktrees (`agent-foo`, short ids, uppercase) keep capturing; a future harness rename simply stops matching (no regression).
- **PostToolUse writer** — early-exit before any capture work.
- **PreCompact hook** — whole-hook early-exit: checkpoint, `session_state.md`, and the opt-in safety-net commit would all land in the ephemeral worktree / agent branch. (Scope note: this is slightly wider than "capture" alone — flagged for review.)
- **Opt-out** — `CCMEMO_CAPTURE_AGENT_WORKTREES=1` restores capture everywhere. Default-on otherwise, zero config.
- Docs: agent-worktree paragraph + env var in `docs/architecture.md`.

## Testing

- `tests/test_agent_worktree.py` (new, dependency-free): 17 checks — pattern matrix (harness names suppressed / user names & near-misses kept), opt-out env, and end-to-end runs of the PostToolUse writer (capture written in a normal checkout, suppressed inside an `agent-<hex>` worktree).
- Existing self-tests all pass: `test_autocommit.py`, `test_kb_graph.py`, `test_policy.py`.

## Out of scope

- `stop_context_guard.py` (writes no files) and `sessionend_autocommit.py` are untouched.
- The complementary user-worktree mirror-back is #18.