### PR TITLE
feat(hooks): mirror worktree-local .claude/tasks/ back to the main checkout

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,31 @@ worktree. Detection matches only the harness naming convention, so user-named
 worktrees keep capturing. Set `CCMEMO_CAPTURE_AGENT_WORKTREES=1` to opt out of
 the suppression.
 
+### Task mirroring for worktrees (issue-centric mode)
+
+In issue-centric mode `.claude/tasks/` is gitignored, so linked worktrees have
+no transport for task files: gitignored files are not checked out into a new
+worktree, and files written inside one die with it.
+
+- **Outbound (worktree → main checkout):** a SessionEnd hook
+  (`sessionend_tasks_mirror.py`) mirrors `.claude/tasks/` back to the main
+  checkout when the session ran inside a linked worktree. Copy-only — nothing
+  is deleted or overwritten; byte-identical targets are skipped, and a
+  differing existing target gets the copy written alongside as
+  `<name>-from-<worktree-basename><ext>`. The hook no-ops in git-tracked mode
+  (commits are the transport there), in harness-generated agent worktrees,
+  and outside worktrees. Opt-out: `CCMEMO_TASKS_MIRROR=0`.
+- **Inbound (main checkout → worktree):** list the directory in the
+  repository's `.worktreeinclude` file — Claude Code copies the listed
+  gitignored files into worktrees it creates:
+
+  ```
+  .claude/tasks/**
+  ```
+
+  Caveat: `.worktreeinclude` applies only to worktrees the harness creates,
+  not to worktrees made by external scripts with plain `git worktree add`.
+
 ### Checkpoint lifecycle
 
 Checkpoints saved by the PreCompact hook are consumed by `/plan-task` on the next

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -38,6 +38,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/sessionend_tasks_mirror.py\"",
+            "timeout": 15
+          },
+          {
+            "type": "command",
             "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/sessionend_autocommit.py\"",
             "timeout": 30
           }

--- a/hooks/sessionend_tasks_mirror.py
+++ b/hooks/sessionend_tasks_mirror.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""SessionEnd hook: mirror worktree-local .claude/tasks/ back to the main checkout.
+
+In issue-centric mode `.claude/tasks/` is gitignored (multi-user repos keep
+per-worker scratchpads out of commits), so commits cannot transport task
+files out of a linked worktree — anything written there dies with the
+worktree. This hook copies task files back to the main checkout when a
+session that ran inside a linked worktree ends (issue #18).
+
+Rules:
+- Runs only when `.claude/tasks` is actually gitignored in the worktree —
+  in git-tracked mode commits are the transport and mirroring would just
+  dirty the main checkout.
+- Copy-only: never deletes or overwrites on either side. Byte-identical
+  targets are skipped; a differing existing target gets the copy written
+  alongside as `<name>-from-<worktree-basename><ext>` (that suffixed slot
+  belongs to this worktree and is refreshed on later runs).
+- Harness-generated agent worktrees are skipped entirely (leaves must not
+  write `.claude/tasks/`; capture there is already suppressed — see #17).
+- Fail-open: any error exits 0 silently.
+
+Opt-out: CCMEMO_TASKS_MIRROR=0
+"""
+
+import filecmp
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from lib.agent_worktree import is_agent_worktree  # noqa: E402
+
+
+def _git(cwd, *args):
+    """Run git in cwd; return CompletedProcess or None on failure to spawn."""
+    try:
+        return subprocess.run(
+            ["git", "-C", cwd, *args],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def linked_worktree_roots(cwd):
+    """Return (worktree_root, main_checkout) if cwd is inside a linked
+    worktree, else None."""
+    out = _git(cwd, "rev-parse", "--git-dir", "--git-common-dir")
+    if out is None or out.returncode != 0:
+        return None
+    lines = out.stdout.splitlines()
+    if len(lines) != 2:
+        return None
+    git_dir, common_dir = (
+        os.path.abspath(os.path.join(cwd, p)) for p in lines
+    )
+    if git_dir == common_dir:
+        return None  # main checkout, not a linked worktree
+
+    toplevel = _git(cwd, "rev-parse", "--show-toplevel")
+    if toplevel is None or toplevel.returncode != 0:
+        return None
+    wt_root = toplevel.stdout.strip()
+    main_checkout = os.path.dirname(common_dir)
+    return wt_root, main_checkout
+
+
+def tasks_gitignored(wt_root):
+    """True only when .claude/tasks is ignored (issue-centric mode)."""
+    out = _git(wt_root, "check-ignore", "-q", "--", ".claude/tasks")
+    return out is not None and out.returncode == 0
+
+
+def mirror(src_root, dst_root, suffix):
+    """Copy src_root into dst_root without overwriting differing targets."""
+    copied, shadowed = [], []
+    for dirpath, _dirnames, filenames in os.walk(src_root):
+        rel_dir = os.path.relpath(dirpath, src_root)
+        for fn in sorted(filenames):
+            src = os.path.join(dirpath, fn)
+            rel = os.path.normpath(os.path.join(rel_dir, fn))
+            dst = os.path.join(dst_root, rel)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            if not os.path.exists(dst):
+                shutil.copy2(src, dst)
+                copied.append(rel)
+            elif filecmp.cmp(src, dst, shallow=False):
+                continue
+            else:
+                stem, ext = os.path.splitext(dst)
+                alt = f"{stem}-from-{suffix}{ext}"
+                if os.path.exists(alt) and filecmp.cmp(src, alt, shallow=False):
+                    continue
+                shutil.copy2(src, alt)
+                shadowed.append(os.path.relpath(alt, dst_root))
+    return copied, shadowed
+
+
+def main():
+    if os.environ.get("CCMEMO_TASKS_MIRROR") == "0":
+        return
+    try:
+        input_data = json.load(sys.stdin)
+    except (json.JSONDecodeError, EOFError):
+        return
+    cwd = input_data.get("cwd", os.getcwd())
+
+    if is_agent_worktree(cwd):
+        return
+
+    roots = linked_worktree_roots(cwd)
+    if not roots:
+        return
+    wt_root, main_checkout = roots
+
+    src_root = os.path.join(wt_root, ".claude", "tasks")
+    dst_root = os.path.join(main_checkout, ".claude", "tasks")
+    if not os.path.isdir(src_root):
+        return
+    if os.path.realpath(src_root) == os.path.realpath(dst_root):
+        return
+    if not tasks_gitignored(wt_root):
+        return  # git-tracked mode: commits are the transport
+
+    try:
+        copied, shadowed = mirror(
+            src_root, dst_root, os.path.basename(wt_root)
+        )
+    except OSError:
+        return
+
+    if copied or shadowed:
+        print(json.dumps({"systemMessage": (
+            f"[ccmemo] tasks mirror: {len(copied)} copied, "
+            f"{len(shadowed)} shadow-copied to {dst_root}"
+        )}, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tasks_mirror.py
+++ b/tests/test_tasks_mirror.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Dependency-free self-tests for hooks/sessionend_tasks_mirror.py (issue #18).
+
+Run: python3 tests/test_tasks_mirror.py   (exit 0 = all pass)
+
+Each case builds a throwaway git repo with a linked worktree and runs the
+hook as a subprocess, exactly as the harness would.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HOOK = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..", "hooks", "sessionend_tasks_mirror.py",
+)
+
+FAILURES: list[str] = []
+
+
+def check(name: str, cond: bool) -> None:
+    if cond:
+        print(f"PASS: {name}")
+    else:
+        print(f"FAIL: {name}")
+        FAILURES.append(name)
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", "-C", repo, *args], capture_output=True, text=True, check=True
+    )
+
+
+def make_repo(base, gitignore_tasks=True):
+    repo = os.path.join(base, "repo")
+    os.makedirs(repo)
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.invalid")
+    _git(repo, "config", "user.name", "test")
+    with open(os.path.join(repo, "README.md"), "w") as f:
+        f.write("test\n")
+    if gitignore_tasks:
+        with open(os.path.join(repo, ".gitignore"), "w") as f:
+            f.write(".claude/tasks/\n.claude/worktrees/\n")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-q", "-m", "init")
+    return repo
+
+
+def add_worktree(repo, path, branch):
+    _git(repo, "worktree", "add", "-q", path, "-b", branch)
+    return path
+
+
+def write(path, content):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+
+def run_hook(cwd, env_extra=None):
+    env = dict(os.environ)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(
+        [sys.executable, HOOK],
+        input=json.dumps({"cwd": cwd, "hook_event_name": "SessionEnd"}),
+        capture_output=True, text=True, env=env, check=True,
+    )
+
+
+def main() -> None:
+    base = tempfile.mkdtemp(prefix="ccmemo-i18-")
+    try:
+        # --- issue-centric repo with a linked worktree ---------------------
+        repo = make_repo(base)
+        wt = add_worktree(repo, os.path.join(base, "wt-alpha"), "t1")
+        main_tasks = os.path.join(repo, ".claude", "tasks")
+
+        # 1. new file is copied
+        write(os.path.join(wt, ".claude", "tasks", "demo", "note.md"), "v1\n")
+        run_hook(wt)
+        target = os.path.join(main_tasks, "demo", "note.md")
+        check("new file copied to main checkout",
+              os.path.isfile(target) and open(target).read() == "v1\n")
+
+        # 2. identical file is skipped (no shadow copy appears)
+        run_hook(wt)
+        shadow = os.path.join(main_tasks, "demo", "note-from-wt-alpha.md")
+        check("identical file skipped (no shadow)", not os.path.exists(shadow))
+
+        # 3. differing target: shadow copy, original untouched
+        write(os.path.join(main_tasks, "demo", "note.md"), "main-edit\n")
+        write(os.path.join(wt, ".claude", "tasks", "demo", "note.md"), "v2\n")
+        run_hook(wt)
+        check("differing target untouched",
+              open(target).read() == "main-edit\n")
+        check("shadow copy written with worktree suffix",
+              os.path.isfile(shadow) and open(shadow).read() == "v2\n")
+
+        # 4. shadow slot refreshes on a later run
+        write(os.path.join(wt, ".claude", "tasks", "demo", "note.md"), "v3\n")
+        run_hook(wt)
+        check("shadow slot refreshed", open(shadow).read() == "v3\n")
+
+        # 5. opt-out env
+        write(os.path.join(wt, ".claude", "tasks", "demo", "extra.md"), "x\n")
+        run_hook(wt, {"CCMEMO_TASKS_MIRROR": "0"})
+        check("opt-out env disables mirroring",
+              not os.path.exists(os.path.join(main_tasks, "demo", "extra.md")))
+
+        # 6. main checkout (not a worktree) is a no-op
+        write(os.path.join(repo, ".claude", "tasks", "demo", "own.md"), "y\n")
+        before = set(os.listdir(os.path.join(main_tasks, "demo")))
+        run_hook(repo)
+        after = set(os.listdir(os.path.join(main_tasks, "demo")))
+        check("main checkout no-op", before == after)
+
+        # 7. agent worktree is skipped
+        agent_wt = add_worktree(
+            repo,
+            os.path.join(repo, ".claude", "worktrees", "agent-a18749543825882f6"),
+            "t2",
+        )
+        write(os.path.join(agent_wt, ".claude", "tasks", "demo", "leaf.md"), "z\n")
+        run_hook(agent_wt)
+        check("agent worktree skipped",
+              not os.path.exists(os.path.join(main_tasks, "demo", "leaf.md")))
+
+        # --- git-tracked repo (tasks NOT ignored) ---------------------------
+        base2 = os.path.join(base, "tracked")
+        os.makedirs(base2)
+        repo2 = make_repo(base2, gitignore_tasks=False)
+        wt2 = add_worktree(repo2, os.path.join(base2, "wt-beta"), "t1")
+        write(os.path.join(wt2, ".claude", "tasks", "demo", "note.md"), "t\n")
+        run_hook(wt2)
+        check("git-tracked mode no-op (commits are the transport)",
+              not os.path.exists(
+                  os.path.join(repo2, ".claude", "tasks", "demo", "note.md")))
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+    print("----")
+    if FAILURES:
+        print(f"{len(FAILURES)} failure(s)")
+        sys.exit(1)
+    print("all tests passed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #18.

## Summary

SessionEnd hook that copies `.claude/tasks/` from a linked worktree back to the main checkout, for **issue-centric mode** where the directory is gitignored and commits cannot transport it.

## Behavior

- Worktree detection is pure git plumbing: `rev-parse --git-dir --git-common-dir` differ → linked worktree; main checkout = parent of the common dir.
- **Copy-only, never destructive**: byte-identical targets skipped; a differing existing target is never overwritten — the copy lands alongside as `<name>-from-<worktree-basename><ext>` (that suffixed slot belongs to the worktree and refreshes on later runs).
- Gates (all no-op):
  - git-tracked mode (`check-ignore` on `.claude/tasks` decides) — commits are the transport there, mirroring would only dirty the main checkout
  - harness-generated agent worktrees (#17 boundary — leaves must not produce task files)
  - not in a worktree / any error (fail-open)
- Opt-out: `CCMEMO_TASKS_MIRROR=0`
- Docs: outbound hook + inbound `.worktreeinclude` guidance (`.claude/tasks/**`) in `docs/architecture.md`.

## Testing

`tests/test_tasks_mirror.py` (dependency-free, real git repos + worktrees): 9/9 pass — copy / skip-identical / shadow-on-diff / shadow refresh / opt-out / main-checkout no-op / agent-worktree skip / tracked-mode no-op. Existing self-tests all pass.

## Notes

- Release bump is deferred: #19 is in flight in parallel; a single v1.16.0 release PR will follow once both land.