### PR TITLE
feat(scripts): add kb_graph link-add for deterministic see-link edits

### DIFF
--- a/scripts/kb_graph.py
+++ b/scripts/kb_graph.py
@@ -9,6 +9,7 @@ Subcommands:
   stats                  graph overview: hubs, orphans, components
   neighborhood <entry>   BFS neighborhood (structure only, no body text)
   path <a> <b>           shortest link path between two entries
+  link-add <src> <dst>   deterministically append a see:/ref: line to src
   lint [files...]        deterministic checks (pre-commit friendly, exit 1 on findings)
 
 Output contains entry IDs, titles and edge types only — never body text —
@@ -23,7 +24,17 @@ Usage (from the project root):
     python3 scripts/kb_graph.py stats
     python3 scripts/kb_graph.py neighborhood <partial-name> --depth 2
     python3 scripts/kb_graph.py path <partial-name-a> <partial-name-b>
+    python3 scripts/kb_graph.py link-add <partial-a> <partial-b> \
+        --reason "relationship" --bidirectional
     python3 scripts/kb_graph.py lint [changed-files...]
+
+link-add is the writer counterpart of the graph reader: the model decides
+WHICH entries to connect and writes the reason; the mechanical edit is
+deterministic. It appends after the entry's last see:/ref: line (or after a
+`## 関連` heading), is idempotent per target, writes atomically, and exits
+non-zero on any ambiguity so the caller can fall back to a manual edit.
+With --bidirectional both directions are validated before either file is
+written (no partial application).
 
 Entries are addressed by unique filename substring. `--json` gives
 machine-readable output. `--root` points at the entries dir
@@ -39,6 +50,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 from collections import deque
 
 LINK_RE = re.compile(r"^\s*-\s+(see|ref):\s*\[([^\]]*)\]\(([^)]+)\)", re.MULTILINE)
@@ -297,6 +309,104 @@ def cmd_lint(nodes, edges, problems, registry_path, only_files, as_json):
     sys.exit(1 if findings else 0)
 
 
+SEE_SECTION_RE = re.compile(r"^##\s*(関連|Related)\s*$", re.MULTILINE)
+
+
+def _resolved_link_targets(text, root, dirpath):
+    """Resolve every see/ref target in text to an entries-root-relative id."""
+    targets = set()
+    for _kind, _label, target in LINK_RE.findall(text):
+        t = target.split("#")[0].strip()
+        if not t or t.startswith(("http://", "https://")):
+            continue
+        cand_root = os.path.normpath(os.path.join(root, t))
+        cand_file = os.path.normpath(os.path.join(dirpath, t))
+        for cand in (cand_root, cand_file):
+            if os.path.exists(cand) and cand.startswith(root + os.sep):
+                targets.add(os.path.relpath(cand, root))
+                break
+    return targets
+
+
+def plan_link(root, nodes, src, dst, kind, reason):
+    """Validate and prepare one src -> dst link insertion.
+
+    Returns None when src already links dst (idempotent skip), else
+    (path, new_text, line). Exits non-zero on any ambiguity — the caller
+    (usually a model) then falls back to a manual edit.
+    """
+    root = os.path.abspath(root)
+    if src == dst:
+        sys.exit("error: refusing to add a self-link")
+    title = nodes[dst]["title"]
+    if not title:
+        sys.exit(f"error: link target has no frontmatter title: {dst}")
+    path = os.path.join(root, src)
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    if dst in _resolved_link_targets(text, root, os.path.dirname(path)):
+        print(f"already linked: {src} -> {dst}")
+        return None
+
+    # Anchor: after the last existing see/ref line, else after a 関連 heading.
+    matches = list(LINK_RE.finditer(text))
+    if matches:
+        end = text.find("\n", matches[-1].start())
+        insert_at = len(text) if end == -1 else end + 1
+    else:
+        m = SEE_SECTION_RE.search(text)
+        if not m:
+            sys.exit(f"error: no see/ref line and no '## 関連' section in {src}; "
+                     "add the first link manually")
+        insert_at = text.find("\n", m.start()) + 1
+        if text[insert_at:insert_at + 1] == "\n":
+            insert_at += 1  # keep the blank line under the heading
+
+    line = f"- {kind}: [{title}]({dst}) — {reason}\n"
+    prefix = text[:insert_at]
+    if prefix and not prefix.endswith("\n"):
+        prefix += "\n"
+    new_text = prefix + line + text[insert_at:]
+    return path, new_text, line
+
+
+def _write_atomic(path, new_text):
+    fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(new_text)
+        os.replace(tmp, path)
+    except OSError:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def cmd_link_add(root, nodes, args):
+    src = resolve_entry(nodes, args.src)
+    dst = resolve_entry(nodes, args.dst)
+    pairs = [(src, dst, args.reason)]
+    if args.bidirectional:
+        pairs.append((dst, src, args.reverse_reason or args.reason))
+
+    # Validate every direction before writing anything: a bidirectional
+    # request either fully applies or fully fails.
+    plans = []
+    for s, d, reason in pairs:
+        plan = plan_link(root, nodes, s, d, args.kind, reason)
+        if plan:
+            plans.append((s, d) + plan)
+
+    for s, d, path, new_text, line in plans:
+        if args.dry_run:
+            print(f"dry-run: would add to {s}:\n  {line}", end="")
+        else:
+            _write_atomic(path, new_text)
+            print(f"linked: {s} -> {d}")
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--root", default=".claude/knowledge/entries",
@@ -310,6 +420,18 @@ def main():
     pa = sub.add_parser("path")
     pa.add_argument("a")
     pa.add_argument("b")
+    la = sub.add_parser("link-add")
+    la.add_argument("src", help="entry to edit (unique filename substring)")
+    la.add_argument("dst", help="entry the new link points at")
+    la.add_argument("--reason", required=True,
+                    help="relationship description appended after the em dash")
+    la.add_argument("--kind", choices=["see", "ref"], default="see")
+    la.add_argument("--bidirectional", action="store_true",
+                    help="also add the reverse link dst -> src")
+    la.add_argument("--reverse-reason", default=None,
+                    help="reason for the reverse link (default: --reason)")
+    la.add_argument("--dry-run", action="store_true",
+                    help="print planned insertions without writing")
     li = sub.add_parser("lint")
     li.add_argument("files", nargs="*",
                     help="limit findings to these files (e.g. staged entries)")
@@ -327,6 +449,8 @@ def main():
         cmd_neighborhood(nodes, edges, resolve_entry(nodes, args.entry), args.depth, args.json)
     elif args.cmd == "path":
         cmd_path(nodes, edges, resolve_entry(nodes, args.a), resolve_entry(nodes, args.b), args.json)
+    elif args.cmd == "link-add":
+        cmd_link_add(args.root, nodes, args)
     elif args.cmd == "lint":
         registry = args.registry or os.path.join(args.root, "..", "CLAUDE.md")
         cmd_lint(nodes, edges, problems, registry, args.files, args.json)

--- a/skills/record-knowledge/procedure.md
+++ b/skills/record-knowledge/procedure.md
@@ -145,5 +145,16 @@ If a near-duplicate is found, reuse the existing tag. Do not create a new one.
    e. **Prepare links**: For each related entry, draft a `- see:` line with a brief relationship description
 5. Create `.claude/knowledge/entries/YYYY/MM/YYYYMMDD-HHMMSS-author-slug.md` (or edit existing entry) — include the see links drafted in step 4
 6. **Tag registry update (mandatory)**: If a new tag was created, add it to the tag registry in `.claude/knowledge/CLAUDE.md` within the same operation
-7. **Add backlinks**: For each entry linked in step 4, edit that entry to add a reciprocal `- see:` link pointing back to the new entry
+7. **Add backlinks (deterministic)**: For each entry linked in step 4, add the reciprocal link with the bundled CLI instead of editing files by hand:
+
+   ```bash
+   python3 "<plugin_root>/scripts/kb_graph.py" --root .claude/knowledge/entries \
+     link-add <related-entry-filename> <new-entry-filename> \
+     --reason "<reverse relationship description>"
+   ```
+
+   - `<plugin_root>` is the plugin base directory — the parent of `skills/`, i.e. the directory containing this procedure file two levels up. It is shown in the skill loading message as "Base directory for this skill"
+   - Entries are addressed by unique filename substring; run from the project root so `--root` resolves
+   - The command is idempotent (an existing link to the same target is skipped) and appends after the entry's last `see:`/`ref:` line or its `## 関連` heading
+   - **Fallback**: if it exits non-zero (no see-block anchor, ambiguous name, missing frontmatter title), edit that one entry manually as before
 8. Return a summary of what was recorded: filename, `#` heading, `##` headings, and linked entries

--- a/tests/test_kb_graph.py
+++ b/tests/test_kb_graph.py
@@ -193,6 +193,119 @@ def test_cli_lint_clean_exits_zero():
         assert res.returncode == 0, (res.stdout, res.stderr)
 
 
+ENTRY_E = "2026/07/20260703-120000-alice-section-only-e.md"
+
+
+def add_entry_e(root):
+    """Entry with a 関連 section but no links yet (heading anchor case)."""
+    path = os.path.join(root, ENTRY_E)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("""---
+title: Section Only E
+created: 2026-07-03
+status: active
+tags: "#pitfall"
+---
+
+Body E.
+
+## 関連
+
+""")
+    return path
+
+
+def read(root, rel):
+    with open(os.path.join(root, rel), encoding="utf-8") as f:
+        return f.read()
+
+
+def test_link_add_appends_after_last_link_and_is_idempotent():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        res = run_cli(root, "link-add", "topic-b", "orphan-c",
+                      "--reason", "test relation")
+        assert res.returncode == 0, (res.stdout, res.stderr)
+        text = read(root, ENTRY_B)
+        line = f"- see: [Orphan C]({ENTRY_C}) — test relation"
+        assert line in text, text
+        # appended directly after the previous last link line
+        assert text.index(line) > text.index("self link on purpose"), text
+        # idempotent rerun: no duplicate, exit 0
+        res = run_cli(root, "link-add", "topic-b", "orphan-c",
+                      "--reason", "test relation")
+        assert res.returncode == 0 and "already linked" in res.stdout, res.stdout
+        assert read(root, ENTRY_B).count(f"({ENTRY_C})") == 1
+
+
+def test_link_add_uses_section_heading_anchor():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        add_entry_e(root)
+        res = run_cli(root, "link-add", "section-only-e", "topic-a",
+                      "--reason", "via heading")
+        assert res.returncode == 0, (res.stdout, res.stderr)
+        text = read(root, ENTRY_E)
+        assert f"## 関連\n\n- see: [Topic A]({ENTRY_A}) — via heading" in text, text
+
+
+def test_link_add_fails_loudly_without_anchor():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        before = read(root, ENTRY_C)
+        res = run_cli(root, "link-add", "orphan-c", "topic-a", "--reason", "x")
+        assert res.returncode != 0, "no anchor must fail"
+        assert "manually" in res.stderr, res.stderr
+        assert read(root, ENTRY_C) == before, "file must be untouched"
+
+
+def test_link_add_bidirectional_validates_before_writing():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        before_a = read(root, ENTRY_A)
+        # reverse direction (orphan-c) has no anchor -> nothing may be written
+        res = run_cli(root, "link-add", "topic-a", "orphan-c",
+                      "--reason", "x", "--bidirectional")
+        assert res.returncode != 0, "must fail on the reverse leg"
+        assert read(root, ENTRY_A) == before_a, "no partial application"
+        # both legs valid -> both written
+        add_entry_e(root)
+        res = run_cli(root, "link-add", "topic-a", "section-only-e",
+                      "--reason", "fwd", "--reverse-reason", "back",
+                      "--bidirectional")
+        assert res.returncode == 0, (res.stdout, res.stderr)
+        assert f"({ENTRY_E}) — fwd" in read(root, ENTRY_A)
+        assert f"({ENTRY_A}) — back" in read(root, ENTRY_E)
+
+
+def test_link_add_dry_run_and_bad_targets():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        before = read(root, ENTRY_B)
+        res = run_cli(root, "link-add", "topic-b", "orphan-c",
+                      "--reason", "x", "--dry-run")
+        assert res.returncode == 0 and "dry-run" in res.stdout, res.stdout
+        assert read(root, ENTRY_B) == before, "dry-run must not write"
+        # target without a frontmatter title
+        res = run_cli(root, "link-add", "topic-b", "notes", "--reason", "x")
+        assert res.returncode != 0 and "title" in res.stderr, res.stderr
+        # self link
+        res = run_cli(root, "link-add", "topic-b", "topic-b", "--reason", "x")
+        assert res.returncode != 0 and "self-link" in res.stderr, res.stderr
+
+
+def test_link_add_result_passes_lint():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        add_entry_e(root)
+        res = run_cli(root, "link-add", "section-only-e", "orphan-c",
+                      "--reason", "clean link")
+        assert res.returncode == 0, res.stderr
+        # the new line must parse as a real edge (E -> C appears in the graph)
+        nodes, edges, _problems = kb_graph.load_graph(root)
+        assert (ENTRY_E, ENTRY_C) in {(s, d) for s, d, _k, _r in edges}, edges
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
Closes #19.

## Summary

Writer counterpart to the v1.15.0 link-graph reader: `kb_graph.py link-add` performs the mechanical see-link edit deterministically, so the recording model only decides **which** entries to connect and writes the reason. Measured motivation: a single-entry extension spent a large share of ~78k tokens on reading/editing files just to add reciprocal links.

## CLI

```
kb_graph.py link-add <src> <dst> --reason "..." [--kind see|ref] [--bidirectional [--reverse-reason "..."]] [--dry-run]
```

- Display title resolved from the target's frontmatter `title:` (prevents paraphrased link text); target path written entries-root-relative
- **Idempotent** per resolved target (existing link → "already linked", exit 0)
- **Append-only**: inserts after the entry's last `see:`/`ref:` line, or after a `## 関連` heading; never reformats anything else
- **Atomic write** (tmp + rename), UTF-8
- **Fails loudly** on ambiguity — no anchor, missing title, self-link, ambiguous substring — so the caller falls back to a manual edit
- `--bidirectional` validates **both directions before writing either file** (no partial application)

## Integration

`record-knowledge` procedure step 7 (Add backlinks) now calls `link-add` with a manual-edit fallback on non-zero exit.

## Testing

6 new self-test cases; full `test_kb_graph.py` suite 13/13. The inserted line parses as a real graph edge (verified via `load_graph`), so `postwrite_check_md_links.py` and `lint` remain a second net.

## Notes

- Release bump deferred: #21 (#18 tasks mirror) is in flight in parallel; a single v1.16.0 release PR follows once both land.