### PR TITLE
release: v1.16.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.15.1",
+  "version": "1.16.0",
   "author": {
     "name": "LevNas"
   },


### PR DESCRIPTION
Version bump shipping #21 (worktree task mirroring) and #22 (kb_graph `link-add`) to version-keyed plugin caches. One-line diff; feature details in the merged PRs.

After merge I'll add the `v1.16.0` tag + GitHub Release per the newly backfilled release convention.