### PR TITLE
feat: typed edges (decision lineage) and lineage subcommand for kb_graph — v1.17.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "author": {
     "name": "LevNas"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.17.0] - 2026-08-15
+
+### Added
+- **Typed edges (decision lineage)** in `scripts/kb_graph.py`: the graph now reads
+  the `superseded_by:` frontmatter field as a `superseded_by` edge (entries-root-relative,
+  the single source for supersede lineage — never duplicated as a list link), plus two
+  typed list links — `- amends:` (correction/addendum note that does not rise to a
+  replacement) and `- extends:` (elaboration/specialization). `see:`/`ref:` stay
+  untyped and fully supported, so existing knowledge bases are unaffected.
+- `scripts/kb_graph.py lineage <entry>` — the supersede chain around an entry: what
+  it (transitively) replaced, the replacement chain forward, and the **current
+  authority** (flagged when not `active`/`draft`). Structure only — IDs, titles,
+  status, never body text — built on demand, pure stdlib.
+- Four deterministic supersede lint checks: `superseded-status-mismatch`
+  (`status:` ⇄ `superseded_by:` must agree), `superseded-broken` (target must
+  exist), `superseded-missing-successor` (`status: superseded` needs a
+  `superseded_by:`), and `supersede-cycle` (reported once per chain member so
+  pre-commit file scoping still catches it). Judgment work — which prose markers
+  deserve typing — stays in `/review-knowledge`; lint stays model-free.
+- `link-add --kind` now also accepts `amends` and `extends`.
+- Tests: supersede-chain fixture (typed edge counts, every new lint finding, cycle
+  termination, per-member cycle scoping, typed `link-add`) in
+  `tests/test_kb_graph.py`.
+
+### Changed
+- `record-knowledge` skill: the Correction Flow's successor-side back-link is now a
+  typed `- amends:` link instead of the prose `- see: corrects [original](...)`;
+  documented when `amends:`/`extends:` apply versus plain `see:` (typed vocabulary
+  kept deliberately minimal).
+- `recall-knowledge` skill: a `superseded` search hit is resolved to the current
+  authority with `kb_graph.py lineage` (the chain may be multi-step) instead of
+  hand-following `superseded_by` links; `lineage` joins the structure-first command
+  set for decision-evolution recalls.
+- `review-knowledge` skill: the precomputed `graph_lint` input now covers the
+  superseded chain check deterministically; multi-step chains are reported via
+  `lineage` so the user sees where a superseded entry actually ends up.
+
+## [1.16.0] - 2026-08-11
+
+### Added
+- `hooks/sessionend_tasks_mirror.py` — SessionEnd hook that mirrors worktree-local
+  `.claude/tasks/` back to the main checkout in issue-centric mode. Copy-only with
+  shadow-copy on conflict; no-ops in git-tracked mode, agent worktrees, and outside
+  worktrees. Opt-out: `CCMEMO_TASKS_MIRROR=0`. (#21)
+- `scripts/kb_graph.py link-add` — deterministic see-link writer: idempotent,
+  append-only, atomic, fails loudly on ambiguity; `--bidirectional` validates both
+  directions before writing either file. record-knowledge step 7 now calls it
+  instead of hand-editing backlinks. (#22)
+
 ## [1.15.0] - 2026-07-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ go structure-first through the `see:`-link graph — pure stdlib, no index:
 ```bash
 python3 scripts/kb_graph.py stats                    # hubs, orphans, components
 python3 scripts/kb_graph.py path <entry-a> <entry-b> # shortest link path
+python3 scripts/kb_graph.py lineage <entry>          # supersede chain → current authority
 ```
 
 All subcommands and the pre-commit lint: [docs/link-graph.md](docs/link-graph.md).
@@ -103,7 +104,7 @@ All subcommands and the pre-commit lint: [docs/link-graph.md](docs/link-graph.md
 - [docs/hybrid-search.md](docs/hybrid-search.md) — semantic search setup &
   verification (incl. corporate TLS and NixOS)
 - [docs/link-graph.md](docs/link-graph.md) — the link-graph CLI:
-  `stats` / `neighborhood` / `path` / `lint`
+  `stats` / `neighborhood` / `path` / `lineage` / `link-add` / `lint`
 - [docs/architecture.md](docs/architecture.md) — scripts & skill wiring, subagent
   delegation, Context Guard
 - [docs/examples.md](docs/examples.md) — personal & team workflow walkthroughs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Three scripts under `scripts/` back the search and review skills:
 |--------|---------|------|-------|
 | `kb_index.py` | `uv` (fastembed, sqlite-vec) | Build/refresh the per-machine vector index (sha256 incremental, idempotent) | v1.11.0 |
 | `kb_search.py` | `uv` (fastembed, sqlite-vec) | Hybrid query: lexical + vector arms, RRF fusion, `see:` 1-hop expansion, frontmatter filters | v1.11.0 |
-| `kb_graph.py` | plain `python3` (pure stdlib) | On-demand link graph: `stats` / `neighborhood` / `path` / deterministic `lint` | v1.15.0 |
+| `kb_graph.py` | plain `python3` (pure stdlib) | On-demand link graph: `stats` / `neighborhood` / `path` / `lineage` / `link-add` / deterministic `lint` | v1.15.0 |
 
 How the skills reach them:
 
@@ -20,7 +20,8 @@ How the skills reach them:
   ripgrep-only when the index or its dependencies are absent, and pointing at
   `kb_index.py` when advising an index build. Multi-hop recalls query
   `kb_graph.py neighborhood` / `path` first and read only the endpoint
-  entries. Details: [hybrid-search.md](hybrid-search.md),
+  entries; superseded hits are resolved to the current authority with
+  `kb_graph.py lineage`. Details: [hybrid-search.md](hybrid-search.md),
   [link-graph.md](link-graph.md).
 - **`/review-knowledge`** has the main agent precompute `kb_graph.py stats` +
   `lint` (deterministic, ~1s, no index needed) and pass the output to the

--- a/docs/link-graph.md
+++ b/docs/link-graph.md
@@ -7,8 +7,10 @@ runs with plain `python3`, needs no `uv`, no vector index, and no network.
 ## Design
 
 - **On-demand graph, no persisted index.** The graph is rebuilt each run from
-  the `- see:` / `- ref:` list links in the entries (~1s for a few hundred
-  entries). There is nothing to go stale and nothing to rebuild after a pull.
+  the list links in the entries (`- see:` / `- ref:` / `- amends:` /
+  `- extends:`) plus the `superseded_by:` frontmatter field (~1s for a few
+  hundred entries). There is nothing to go stale and nothing to rebuild after
+  a pull.
 - **Structure only, never body text.** Output contains entry IDs, titles, and
   edge kinds — so results stay cheap to inject into a model context. The
   intended flow is *structure first, bodies last*: use `neighborhood` / `path`
@@ -16,6 +18,15 @@ runs with plain `python3`, needs no `uv`, no vector index, and no network.
 - **Deterministic lint.** `lint` makes no model calls, so it can gate commits.
   Judgment work — staleness review, missing-connection suggestions — stays in
   `/review-knowledge`.
+
+## Edge kinds
+
+| Kind | Source | Meaning |
+|---|---|---|
+| `see` / `ref` | list link | Untyped association (unchanged, backward compatible) |
+| `amends` | list link | Correction / addendum note — corrects part of the target without replacing it |
+| `extends` | list link | Elaboration — develops or specializes the target |
+| `superseded_by` | `superseded_by:` frontmatter | Full replacement: old entry → its replacement. Single source for supersede lineage — never duplicated as a list link. Entries-root-relative path, at most one per entry |
 
 ## Subcommands
 
@@ -25,6 +36,8 @@ Run from the project root; the default `--root` is `.claude/knowledge/entries`.
 python3 scripts/kb_graph.py stats                    # hubs, orphans, components
 python3 scripts/kb_graph.py neighborhood <entry> --depth 2
 python3 scripts/kb_graph.py path <entry-a> <entry-b> # shortest link path
+python3 scripts/kb_graph.py lineage <entry>          # supersede chain → current authority
+python3 scripts/kb_graph.py link-add <src> <dst> --reason "why"  # deterministic writer
 python3 scripts/kb_graph.py lint                     # exit 1 on findings
 ```
 
@@ -43,6 +56,25 @@ its depth, link direction (`→` outgoing / `←` incoming), and edge kind.
 Shortest link path between two entries, treating links as bidirectional.
 Exits 1 if no path exists.
 
+### `lineage <entry>`
+
+The supersede chain around an entry, built from `superseded_by:` frontmatter
+edges only: what the entry (transitively) replaced, the replacement chain
+forward, and the **current authority** — the newest entry in the chain,
+flagged when its status is not `active`/`draft`. Structure only (IDs, titles,
+status), so a superseded search hit resolves to the entry that actually holds
+the current answer in one command.
+
+### `link-add <src> <dst> --reason "..."`
+
+Deterministic writer counterpart of the graph reader: the model decides which
+entries to connect and writes the reason; the mechanical edit is deterministic.
+Appends after the entry's last link line (or a `## 関連` heading), is
+idempotent per target, writes atomically, and exits non-zero on any ambiguity
+so the caller can fall back to a manual edit. `--kind see|ref|amends|extends`
+(default `see`); `--bidirectional` validates both directions before writing
+either file; `--dry-run` prints the planned insertion.
+
 ### `lint [files...]`
 
 Deterministic integrity checks; exits 1 when there are findings, 0 when clean:
@@ -56,6 +88,10 @@ Deterministic integrity checks; exits 1 when there are findings, 0 when clean:
 | `missing-title` | no `title:` in the frontmatter |
 | `filename` | filename does not match `<date>-<time>-...-<slug>.md` |
 | `unknown-tag` | tag not in the registry (default: `<root>/../CLAUDE.md`, override with `--registry`) |
+| `superseded-status-mismatch` | `superseded_by:` present but `status:` is not `superseded` |
+| `superseded-broken` | `superseded_by:` target resolves to no entry |
+| `superseded-missing-successor` | `status: superseded` but no `superseded_by:` |
+| `supersede-cycle` | `superseded_by:` chain loops — reported once per member so file scoping still catches it |
 
 Passing file arguments limits the *reported* findings to those files (the
 graph is still built from all entries), which is exactly what a pre-commit
@@ -68,9 +104,9 @@ changed=$(git diff --cached --name-only -- .claude/knowledge/entries/)
 
 ## Addressing entries
 
-`neighborhood` and `path` accept an entry's path relative to the entries root,
-or any **unique filename substring** — `docker-compose` is enough if only one
-entry matches. Ambiguous queries fail with the list of candidates.
+Every subcommand that takes an entry accepts its path relative to the entries
+root, or any **unique filename substring** — `docker-compose` is enough if only
+one entry matches. Ambiguous queries fail with the list of candidates.
 
 ## Link resolution
 
@@ -88,13 +124,20 @@ by `lint` but are not part of the entry graph.
 
 ## How the skills use it
 
+- **`/record-knowledge`** — backlinks (step 7) and typed links are written with
+  `link-add` instead of hand-editing entry files; the Correction Flow's
+  successor-side back-link is an `amends:` link.
 - **`/recall-knowledge`** — multi-hop recalls (tracing how a decision evolved,
   connecting two topics, mapping an area) query `neighborhood` / `path` first
   and read only the endpoint entries, instead of chaining
-  search → read → follow links → read again.
+  search → read → follow links → read again. A `superseded` hit is resolved to
+  the current authority with `lineage`.
 - **`/review-knowledge`** — the main agent precomputes `stats` + `lint` and
   passes the output to the review subagent, which spends its effort on
-  judgment work instead of re-deriving link facts by hand.
+  judgment work instead of re-deriving link facts by hand. The supersede-chain
+  part of the health check is covered by the four deterministic lint checks;
+  typing judgment (which prose markers deserve `amends:`/`extends:`) stays
+  with the reviewer.
 
 ## Related
 

--- a/scripts/kb_graph.py
+++ b/scripts/kb_graph.py
@@ -9,8 +9,16 @@ Subcommands:
   stats                  graph overview: hubs, orphans, components
   neighborhood <entry>   BFS neighborhood (structure only, no body text)
   path <a> <b>           shortest link path between two entries
-  link-add <src> <dst>   deterministically append a see:/ref: line to src
+  lineage <entry>        supersede chain: what this replaced, what replaced it
+  link-add <src> <dst>   deterministically append a typed link line to src
   lint [files...]        deterministic checks (pre-commit friendly, exit 1 on findings)
+
+Edge kinds:
+  see / ref              untyped association (list links, unchanged)
+  amends / extends       typed list links: correction note / elaboration
+  superseded_by          derived from the `superseded_by:` frontmatter field
+                         (correction flow) — old entry -> replacement, max one
+                         per entry, entries-root-relative path only
 
 Output contains entry IDs, titles and edge types only — never body text —
 so results stay cheap to inject into a model context. The intended flow is
@@ -53,7 +61,7 @@ import sys
 import tempfile
 from collections import deque
 
-LINK_RE = re.compile(r"^\s*-\s+(see|ref):\s*\[([^\]]*)\]\(([^)]+)\)", re.MULTILINE)
+LINK_RE = re.compile(r"^\s*-\s+(see|ref|amends|extends):\s*\[([^\]]*)\]\(([^)]+)\)", re.MULTILINE)
 # Both registry line forms in use: "- #tag — description (count)" and "`#tag`"
 TAG_REGISTRY_RES = (
     re.compile(r"^- (#[\w\-]+)", re.MULTILINE),
@@ -103,6 +111,27 @@ def load_graph(root):
                 problems.append((nid, "missing-title", "no frontmatter title"))
             if not FILENAME_RE.match(fn):
                 problems.append((nid, "filename", "does not match <date>-<time>-...-<slug>.md"))
+            sup = meta.get("superseded_by", "")
+            status = meta.get("status", "")
+            if sup:
+                if status != "superseded":
+                    problems.append((nid, "superseded-status-mismatch",
+                                     f"superseded_by present but status is '{status or '(none)'}'"))
+                t = sup.split("#")[0].strip()
+                # spec says entries-root-relative — deliberately no dirpath fallback
+                cand = os.path.normpath(os.path.join(root, t))
+                if os.path.exists(cand) and cand.startswith(root + os.sep):
+                    dst = os.path.relpath(cand, root)
+                    if dst == nid:
+                        problems.append((nid, "self-link", "superseded_by: links to itself"))
+                    else:
+                        edges.append((nid, dst, "superseded_by", "frontmatter"))
+                else:
+                    problems.append((nid, "superseded-broken",
+                                     f"superseded_by: ({sup}) resolves to no entry"))
+            elif status == "superseded":
+                problems.append((nid, "superseded-missing-successor",
+                                 "status: superseded but no superseded_by"))
             for kind, _label, target in LINK_RE.findall(text):
                 t = target.split("#")[0].strip()
                 if not t or t.startswith(("http://", "https://")):
@@ -282,8 +311,77 @@ def cmd_path(nodes, edges, a, b, as_json):
     print(f"\n{len(chain)} hops")
 
 
+def supersede_maps(edges):
+    nxt, prevs = {}, {}
+    for s, d, k, _r in edges:
+        if k == "superseded_by":
+            nxt[s] = d  # max one superseded_by per entry -> chain structure
+            prevs.setdefault(d, []).append(s)
+    return nxt, prevs
+
+
+def supersede_cycles(edges):
+    nxt, _prevs = supersede_maps(edges)
+    cycles, done = [], set()
+    for start in nxt:
+        if start in done:
+            continue
+        order = {}
+        cur = start
+        while cur in nxt and cur not in order and cur not in done:
+            order[cur] = len(order)
+            cur = nxt[cur]
+        if cur in order:
+            chain = sorted(order, key=order.get)
+            cycles.append(chain[order[cur]:])
+        done.update(order)
+    return cycles
+
+
+def cmd_lineage(nodes, edges, start, as_json):
+    nxt, prevs = supersede_maps(edges)
+    ancestors = []  # entries this one (transitively) replaced
+    q = deque([start])
+    seen = {start}
+    while q:
+        for p in sorted(prevs.get(q.popleft(), [])):
+            if p not in seen:
+                seen.add(p)
+                ancestors.append(p)
+                q.append(p)
+    successors = []  # replacement chain from this entry forward
+    cur = start
+    while cur in nxt and nxt[cur] not in successors and nxt[cur] != start:
+        cur = nxt[cur]
+        successors.append(cur)
+    current = successors[-1] if successors else start
+    if as_json:
+        print(json.dumps({
+            "entry": start,
+            "ancestors": [{"id": n, "title": nodes[n]["title"]} for n in ancestors],
+            "successors": [{"id": n, "title": nodes[n]["title"]} for n in successors],
+            "current": {"id": current, "title": nodes[current]["title"],
+                        "status": nodes[current]["status"]},
+        }, ensure_ascii=False, indent=1))
+        return
+    print(f"{start}\n  {short(nodes[start]['title'])}")
+    if ancestors:
+        print("\nreplaces (transitively):")
+        for n in ancestors:
+            print(f"  ← {n}\n      {short(nodes[n]['title'])}")
+    if successors:
+        print("\nreplaced by (chain):")
+        for n in successors:
+            print(f"  → {n}\n      {short(nodes[n]['title'])}")
+    flag = "" if nodes[current]["status"] in ("active", "draft") else f"  [status: {nodes[current]['status']}]"
+    print(f"\ncurrent authority: {current}{flag}")
+
+
 def cmd_lint(nodes, edges, problems, registry_path, only_files, as_json):
     findings = list(problems)
+    for cyc in supersede_cycles(edges):
+        for nid in cyc:  # one finding per member so the only_files filter still hits
+            findings.append((nid, "supersede-cycle", " → ".join(cyc + [cyc[0]])))
     if registry_path and os.path.isfile(registry_path):
         with open(registry_path, encoding="utf-8") as f:
             registry_text = f.read()
@@ -420,12 +518,14 @@ def main():
     pa = sub.add_parser("path")
     pa.add_argument("a")
     pa.add_argument("b")
+    lg = sub.add_parser("lineage")
+    lg.add_argument("entry")
     la = sub.add_parser("link-add")
     la.add_argument("src", help="entry to edit (unique filename substring)")
     la.add_argument("dst", help="entry the new link points at")
     la.add_argument("--reason", required=True,
                     help="relationship description appended after the em dash")
-    la.add_argument("--kind", choices=["see", "ref"], default="see")
+    la.add_argument("--kind", choices=["see", "ref", "amends", "extends"], default="see")
     la.add_argument("--bidirectional", action="store_true",
                     help="also add the reverse link dst -> src")
     la.add_argument("--reverse-reason", default=None,
@@ -449,6 +549,8 @@ def main():
         cmd_neighborhood(nodes, edges, resolve_entry(nodes, args.entry), args.depth, args.json)
     elif args.cmd == "path":
         cmd_path(nodes, edges, resolve_entry(nodes, args.a), resolve_entry(nodes, args.b), args.json)
+    elif args.cmd == "lineage":
+        cmd_lineage(nodes, edges, resolve_entry(nodes, args.entry), args.json)
     elif args.cmd == "link-add":
         cmd_link_add(args.root, nodes, args)
     elif args.cmd == "lint":

--- a/skills/recall-knowledge/procedure.md
+++ b/skills/recall-knowledge/procedure.md
@@ -64,10 +64,15 @@ full body just to decide where to go next). Instead:
 ```bash
 python3 "{plugin_root}/scripts/kb_graph.py" --root "{KB_ROOT}" neighborhood <entry> --depth 2
 python3 "{plugin_root}/scripts/kb_graph.py" --root "{KB_ROOT}" path <entryA> <entryB>
+python3 "{plugin_root}/scripts/kb_graph.py" --root "{KB_ROOT}" lineage <entry>
 ```
 
 - Entries are addressed by unique filename substring; use Step 3a/3b (or `stats` for
   hubs) only to identify the starting entry when it is not already known.
+- Decision-evolution questions map directly to `lineage`: it prints what the entry
+  (transitively) replaced, the replacement chain forward, and the **current
+  authority** — derived from the `superseded_by:` frontmatter, one command instead
+  of hand-following links.
 - Output is structure only — IDs, titles, edge kinds, never body text — so it is cheap
   to keep in context. Plan the route from it, then **Read only the endpoint entries**
   (typically 1–3) that actually answer the question.
@@ -76,6 +81,9 @@ python3 "{plugin_root}/scripts/kb_graph.py" --root "{KB_ROOT}" path <entryA> <en
 ## Step 4. Present results
 - Show the ranked entries as printed by kb_search.py: score, title, relpath, tags, snippet.
 - For the top 1–2 hits, **Read** the entry file when its content is needed to answer.
-- Prefer `status: active`; if a top hit is `superseded`/`deprecated`, note it and prefer its
-  replacement (follow `superseded_by` / `see:` links).
+- Prefer `status: active`; if a top hit is `superseded`, run
+  `python3 "{plugin_root}/scripts/kb_graph.py" --root "{KB_ROOT}" lineage <entry>` to
+  jump to the current authority (the chain may be multi-step), answer from that entry,
+  and note the supersession. For `deprecated` hits, note it and prefer `see:`-linked
+  replacements.
 - Keep output concise — return the ranked list and the synthesized answer, not raw tool noise.

--- a/skills/record-knowledge/procedure.md
+++ b/skills/record-knowledge/procedure.md
@@ -55,6 +55,8 @@ tags: "#tag1 #tag2 ..."
 
 - ref: [display text](URL or relative path)
 - see: [related entry title](YYYY/MM/slug.md) — relationship description
+- amends: [corrected entry title](YYYY/MM/slug.md) — what this corrects
+- extends: [base entry title](YYYY/MM/slug.md) — what this elaborates
 ```
 
 - Keep entries focused and under **100 KB** where possible
@@ -99,6 +101,19 @@ If a near-duplicate is found, reuse the existing tag. Do not create a new one.
   - **Design decision ↔ rationale**: architecture choice ↔ supporting evidence
 - Bidirectional links by default (if A → B, add B → A too)
 
+### Typed Links (`amends:` / `extends:`)
+
+Two typed list links carry lineage semantics that plain `see:` does not; `kb_graph.py` reads them as distinct edge kinds. Same line format as `see:`.
+
+| Kind | Meaning | Use when |
+|------|---------|----------|
+| `amends:` | Correction / addendum note | This entry corrects or supplements part of the target **without replacing it** — and, in the Correction Flow, the replacement entry pointing back at the entry it supersedes |
+| `extends:` | Elaboration | This entry develops, specializes, or builds on the target |
+
+- When neither applies, use plain `see:` — the typed vocabulary is deliberately minimal
+- `see:`/`ref:` stay untyped and fully supported; do NOT retype existing links in bulk
+- Full replacement is not a typed link: supersede lineage lives **only** in the `superseded_by:` frontmatter field (single source — never duplicate it as a list link). `kb_graph.py lineage` derives chains from it.
+
 ## Status Definitions
 
 | Status | Meaning |
@@ -117,9 +132,11 @@ If a near-duplicate is found, reuse the existing tag. Do not create a new one.
 | `high` | Verified multiple times, well-established |
 
 ### Correction Flow (superseded)
-1. Set `status: superseded` and add `superseded_by: YYYY/MM/newer-entry-slug.md`
-2. Create the replacement entry with a `- see:` link: `corrects [original title](YYYY/MM/original.md)`
+1. Set `status: superseded` and add `superseded_by: YYYY/MM/newer-entry-slug.md` (entries/-relative path)
+2. Create the replacement entry with an `- amends:` back-link: `- amends: [original title](YYYY/MM/original.md) — what was corrected`
 3. Keep the original entry intact
+
+`kb_graph.py lint` enforces the frontmatter pair deterministically (`superseded-status-mismatch`, `superseded-broken`, `superseded-missing-successor`, `supersede-cycle`).
 
 ## Amendment Rules
 - Entries are **mutable** — edit in place (git tracks change history)
@@ -155,6 +172,7 @@ If a near-duplicate is found, reuse the existing tag. Do not create a new one.
 
    - `<plugin_root>` is the plugin base directory — the parent of `skills/`, i.e. the directory containing this procedure file two levels up. It is shown in the skill loading message as "Base directory for this skill"
    - Entries are addressed by unique filename substring; run from the project root so `--root` resolves
-   - The command is idempotent (an existing link to the same target is skipped) and appends after the entry's last `see:`/`ref:` line or its `## 関連` heading
+   - Add `--kind amends` / `--kind extends` when the relationship is typed (default: `see`)
+   - The command is idempotent (an existing link to the same target is skipped) and appends after the entry's last link line (`see:`/`ref:`/`amends:`/`extends:`) or its `## 関連` heading
    - **Fallback**: if it exits non-zero (no see-block anchor, ambiguous name, missing frontmatter title), edit that one entry manually as before
 8. Return a summary of what was recorded: filename, `#` heading, `##` headings, and linked entries

--- a/skills/review-knowledge/procedure.md
+++ b/skills/review-knowledge/procedure.md
@@ -18,7 +18,9 @@ The input may contain `graph_stats` and `graph_lint` sections — deterministic 
 - `graph_stats` covers orphan detection (b), and the connectivity part of the summary
   statistics (e): hubs, edge counts, connected components
 - `graph_lint` covers broken see links (g), broken file references (h — `broken-link`
-  and `out-of-tree` findings), unregistered tags (part of d), plus `self-link`,
+  and `out-of-tree` findings), unregistered tags (part of d), the superseded chain
+  check (k — `superseded-status-mismatch`, `superseded-broken`,
+  `superseded-missing-successor`, `supersede-cycle`), plus `self-link`,
   `duplicate-link`, `missing-title`, and `filename` findings
 
 Spend the saved effort on the judgment sections the script cannot do: staleness (a),
@@ -88,6 +90,12 @@ Scan the entire knowledge base and report:
 #### k. Superseded Chain Check
 - Entries with `status: superseded` must have a valid `superseded_by` path
 - Check that the replacement entry exists and is `active`
+- `graph_lint` covers the mechanical part deterministically
+  (`superseded-status-mismatch` / `superseded-broken` /
+  `superseded-missing-successor` / `supersede-cycle`)
+- For multi-step chains, `kb_graph.py lineage <entry>` prints the full chain and
+  the current authority — use it when reporting so the user sees where a
+  superseded entry actually ends up
 - Report broken superseded chains
 
 #### l. Missing Overview

--- a/tests/test_kb_graph.py
+++ b/tests/test_kb_graph.py
@@ -306,6 +306,125 @@ def test_link_add_result_passes_lint():
         assert (ENTRY_E, ENTRY_C) in {(s, d) for s, d, _k, _r in edges}, edges
 
 
+LIN_A = "2026/08/20260801-100000-alice-design-old.md"
+LIN_B = "2026/08/20260802-100000-alice-design-mid.md"
+LIN_C = "2026/08/20260803-100000-alice-design-current.md"
+LIN_D = "2026/08/20260804-100000-alice-mismatch.md"
+LIN_E = "2026/08/20260805-100000-alice-no-successor.md"
+LIN_G = "2026/08/20260806-100000-alice-cycle-g.md"
+LIN_H = "2026/08/20260807-100000-alice-cycle-h.md"
+
+
+def make_lineage_kb(base):
+    """Supersede chain A→B→C plus every supersede lint defect: status
+    mismatch and broken target (both on D), missing successor (E), and a
+    two-entry cycle (G⇄H). C carries an amends link, E an extends link."""
+    root = os.path.join(base, "repo", ".claude", "knowledge", "entries")
+    os.makedirs(os.path.join(root, "2026", "08"))
+
+    def write(relpath, title, status, superseded_by=None, links=""):
+        lines = ["---", f"title: {title}", "created: 2026-08-01",
+                 f"status: {status}"]
+        if superseded_by:
+            lines.append(f"superseded_by: {superseded_by}")
+        lines += ['tags: "#design"', "---", "", f"Body of {title}.", ""]
+        with open(os.path.join(root, relpath), "w", encoding="utf-8") as f:
+            f.write("\n".join(lines) + links)
+
+    write(LIN_A, "Design old", "superseded", superseded_by=LIN_B)
+    write(LIN_B, "Design mid", "superseded", superseded_by=LIN_C)
+    write(LIN_C, "Design current", "active",
+          links=f"- amends: [Design old]({LIN_A}) — corrects the original scope\n")
+    write(LIN_D, "Mismatch", "active", superseded_by="2026/08/nonexistent.md")
+    write(LIN_E, "No successor", "superseded",
+          links=f"- extends: [Design current]({LIN_C}) — elaborates the rollout\n")
+    write(LIN_G, "Cycle G", "superseded", superseded_by=LIN_H)
+    write(LIN_H, "Cycle H", "superseded", superseded_by=LIN_G)
+
+    with open(os.path.join(base, "repo", ".claude", "knowledge", "CLAUDE.md"),
+              "w", encoding="utf-8") as f:
+        f.write("- #design — design lineage fixtures (7)\n")
+    return root
+
+
+def test_typed_edges_and_superseded_frontmatter():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_lineage_kb(base)
+        nodes, edges, problems = kb_graph.load_graph(root)
+        kinds = {}
+        for _s, _d, k, _r in edges:
+            kinds[k] = kinds.get(k, 0) + 1
+        assert kinds == {"superseded_by": 4, "amends": 1, "extends": 1}, kinds
+        triples = {(s, d, k) for s, d, k, _r in edges}
+        assert (LIN_A, LIN_B, "superseded_by") in triples, triples
+        assert (LIN_C, LIN_A, "amends") in triples, triples
+        assert (LIN_E, LIN_C, "extends") in triples, triples
+        checks = {(nid, check) for nid, check, _ in problems}
+        assert (LIN_D, "superseded-status-mismatch") in checks, checks
+        assert (LIN_D, "superseded-broken") in checks, checks
+        assert (LIN_E, "superseded-missing-successor") in checks, checks
+        # D's broken superseded_by must not produce an edge
+        assert not any(s == LIN_D for s, _d, _k, _r in edges), edges
+
+
+def test_cli_lint_supersede_checks_and_cycle_scoping():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_lineage_kb(base)
+        res = run_cli(root, "--json", "lint")
+        assert res.returncode == 1, (res.stdout, res.stderr)
+        findings = json.loads(res.stdout)
+        by_check = {}
+        for f in findings:
+            by_check.setdefault(f["check"], []).append(f["id"])
+        assert by_check.get("superseded-status-mismatch") == [LIN_D], by_check
+        assert by_check.get("superseded-broken") == [LIN_D], by_check
+        assert by_check.get("superseded-missing-successor") == [LIN_E], by_check
+        assert by_check.get("supersede-cycle") == [LIN_G, LIN_H], by_check
+        assert len(findings) == 5, findings
+        # cycle findings are reported per member, so file scoping still hits
+        res = run_cli(root, "--json", "lint", os.path.join(root, LIN_G))
+        scoped = json.loads(res.stdout)
+        assert [(f["id"], f["check"]) for f in scoped] == \
+            [(LIN_G, "supersede-cycle")], scoped
+
+
+def test_cli_lineage():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_lineage_kb(base)
+        res = run_cli(root, "--json", "lineage", "design-old")
+        assert res.returncode == 0, res.stderr
+        data = json.loads(res.stdout)
+        assert [s["id"] for s in data["successors"]] == [LIN_B, LIN_C], data
+        assert data["current"]["id"] == LIN_C, data
+        assert data["current"]["status"] == "active", data
+        assert data["ancestors"] == [], data
+        # reverse direction: the current entry knows what it replaced
+        res = run_cli(root, "--json", "lineage", "design-current")
+        data = json.loads(res.stdout)
+        assert [a["id"] for a in data["ancestors"]] == [LIN_B, LIN_A], data
+        assert data["current"]["id"] == LIN_C, data
+        # text output is structure only — no body text may leak
+        res = run_cli(root, "lineage", "design-old")
+        assert res.returncode == 0 and "Body" not in res.stdout, res.stdout
+        assert "current authority" in res.stdout, res.stdout
+        # a supersede cycle must terminate, not hang
+        res = run_cli(root, "--json", "lineage", "cycle-g")
+        assert res.returncode == 0, res.stderr
+
+
+def test_link_add_typed_kind():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        res = run_cli(root, "link-add", "topic-b", "orphan-c",
+                      "--kind", "extends", "--reason", "builds on it")
+        assert res.returncode == 0, (res.stdout, res.stderr)
+        line = f"- extends: [Orphan C]({ENTRY_C}) — builds on it"
+        assert line in read(root, ENTRY_B), read(root, ENTRY_B)
+        nodes, edges, _problems = kb_graph.load_graph(root)
+        assert (ENTRY_B, ENTRY_C, "extends") in \
+            {(s, d, k) for s, d, k, _r in edges}, edges
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
Adds decision-lineage support to the link-graph CLI, prototyped and validated externally against a real 262-entry knowledge base (no regressions: the only edge delta is the single frontmatter-derived `superseded_by` edge, zero new lint findings, connected components unchanged).

## What

- **Typed edges** in `scripts/kb_graph.py`:
  - `superseded_by:` frontmatter is now read as a `superseded_by` edge — the single source for supersede lineage (entries-root-relative only, never duplicated as a list link).
  - Two typed list links: `- amends:` (correction/addendum note that does not rise to a replacement) and `- extends:` (elaboration). `see:`/`ref:` stay untyped — fully backward compatible.
- **`lineage <entry>` subcommand** — what the entry (transitively) replaced, the replacement chain forward, and the current authority. Structure only (never body text), on-demand, pure stdlib.
- **Four deterministic lint checks**: `superseded-status-mismatch`, `superseded-broken`, `superseded-missing-successor`, `supersede-cycle` (reported per chain member so pre-commit file scoping still hits). Typing judgment from prose markers stays LLM work in /review-knowledge.
- `link-add --kind` accepts `amends`/`extends`.

## Skill wiring

- **record-knowledge**: Correction Flow's successor-side back-link is now `- amends:` (was prose `- see: corrects …`); usage criteria for the minimal typed vocabulary documented.
- **recall-knowledge / review-knowledge**: a `superseded` hit resolves to the current authority via `lineage`; review's precomputed `graph_lint` covers the supersede-chain checks.

## Tests

`tests/test_kb_graph.py`: supersede-chain fixture (A→B→C, amends/extends, status mismatch, broken target, missing successor, 2-entry cycle) covering edge-kind counts, all four lint findings, per-member cycle scoping, lineage in both directions, cycle termination, and typed `link-add`. 17/17 pass; the other four suites stay green.

## Release

Bumps the plugin to **v1.17.0** — required because the plugin cache is version-keyed. CHANGELOG gains the 1.17.0 section and backfills the missing 1.16.0 section from its release commit message.