### PR TITLE
fix(hooks): respect frontmatter status in per-prompt auto-search — v1.19.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "author": {
     "name": "LevNas"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.19.0] - 2026-08-16
+
+### Fixed
+- The per-prompt auto-search hook (`hooks/userpromptsubmit_knowledge_search.sh`)
+  now respects frontmatter `status`: `superseded` / `deprecated` entries are
+  no longer injected as current knowledge. Entries
+  without a `status:` line keep surfacing (treated as `active`), the field is
+  read from the frontmatter block only (a body line starting with `status:`
+  cannot leak in), and filtered-out entries do not consume result slots — the
+  hook walks the ranking until `MAX_RESULTS` allowed entries are collected.
+  `kb_search.py --status` and the entry templates already treated non-active
+  entries as reference-only; the always-on injection path was the one place
+  that ignored it.
+- A title-less entry file no longer aborts the whole hook (`rg` exiting 1
+  under `pipefail` made the `basename` fallback unreachable).
+
+### Added
+- `CCMEMO_SEARCH_STATUS`: comma-separated allowlist of statuses the auto-search
+  hook may surface (default `active`; `all` disables filtering). Non-active
+  entries deliberately surfaced this way are annotated with
+  `[status: …, superseded_by: …]` so the reader sees they are not current.
+- Tests: `tests/test_knowledge_search_hook.py` — runs the hook end-to-end with
+  a stubbed `mecab`; covers default exclusion, missing-status fallback,
+  allowlist widening with annotation, `all`, slot preservation after
+  filtering, and frontmatter-only field extraction.
+
 ## [1.18.0] - 2026-08-16
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,7 +31,10 @@ How the skills reach them:
   unavailable.
 - The per-prompt `UserPromptSubmit` hook stays **ripgrep-only** (instant,
   model-free injection) — neither the vector index nor the graph CLI is wired
-  into it.
+  into it. Since v1.19.0 it is status-aware: only `active` entries surface by
+  default (`CCMEMO_SEARCH_STATUS` widens or disables the filter, and
+  deliberately surfaced non-active entries carry a `[status: …]` annotation),
+  still with plain rg/awk and no index.
 
 ## Subagent Delegation (since v1.8.0)
 

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -84,6 +84,7 @@ Python 標準ライブラリだけで動き、索引も要りません。
 - **著者**：エントリの `author` フィールドの既定は `@<ユーザー名>` です。Git ホスティングのユーザー名に設定します。
 - **ワークフロー**：`skills/*/SKILL.md` を編集すると、プロジェクト固有の規約（タグの分類、イシューコメントの書式、プランのテンプレート）を足せます。
 - **自動コミット（オプトイン、既定はオフ）**：`CCMEMO_AUTOCOMMIT=1` を設定すると、セーフティネットのフックがセッション終了時（`SessionEnd`）と compaction の前（`PreCompact`）に、`.claude/knowledge/` と `.claude/tasks/` の変更だけをコミットします。`git add -A` は実行せず、push もしません。漏えいしやすい形が差分に含まれる場合は leak-scan ゲートがコミットを止めます（`CCMEMO_AUTOCOMMIT_ON_LEAK=warn` にすると警告つきでコミットします）。これは手動のセッション終了コミットの置き換えではなく補完なので、すでにコミット済みなら何もしません。
+- **自動検索の status フィルタ**：毎プロンプトの `UserPromptSubmit` フックは、frontmatter の `status` が `active` のエントリだけを注入します（`status:` 行が無いエントリは active 扱い）。`CCMEMO_SEARCH_STATUS` にカンマ区切りの許可リスト（例：`active,superseded`）を設定すると広げられ、`all` でフィルタを無効化できます。この経路で表に出た非 active エントリには `[status: …, superseded_by: …]` の注記が付くため、現行の知識と取り違えることはありません。
 
 ## Git リポジトリに置く理由
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,6 +108,13 @@ entries before starting work. Patterns and examples:
   to commit with a warning instead). It complements — does not replace — your
   manual end-of-session commit, so it is a no-op when you have already
   committed.
+- **Auto-search status filter** — the per-prompt `UserPromptSubmit` hook only
+  injects entries whose frontmatter `status` is `active` (entries without a
+  `status:` line count as active). Set `CCMEMO_SEARCH_STATUS` to a
+  comma-separated allowlist (e.g. `active,superseded`) to widen it, or to
+  `all` to disable filtering; non-active entries surfaced that way are
+  annotated with `[status: …, superseded_by: …]` so they cannot be mistaken
+  for current knowledge.
 
 ## Why keep it in a Git repository
 

--- a/hooks/userpromptsubmit_knowledge_search.sh
+++ b/hooks/userpromptsubmit_knowledge_search.sh
@@ -4,12 +4,18 @@
 # Reads prompt JSON from stdin, extracts Japanese nouns with mecab, searches
 # .claude/knowledge/entries/ with rg, and injects the top N hits as
 # additionalContext so Claude sees them before answering.
+#
+# Only entries whose frontmatter status is in CCMEMO_SEARCH_STATUS surface
+# (default: active; entries without a status line count as active; "all"
+# disables the filter). Non-active entries that are deliberately allowed
+# through are annotated with their status and superseded_by target.
 set -euo pipefail
 
 MAX_RESULTS=5
 MIN_WORD_LEN=2
 HIT_COUNT_LIMIT=50
 ENTRIES_DIR=".claude/knowledge/entries"
+ALLOWED_STATUS="${CCMEMO_SEARCH_STATUS:-active}"
 
 # Silently no-op if required tools or entries dir are missing.
 command -v jq >/dev/null 2>&1 || exit 0
@@ -50,17 +56,49 @@ done <<< "$KEYWORDS"
 [ "${#file_scores[@]}" -gt 0 ] || exit 0
 set -u
 
+# Walk the ranking until MAX_RESULTS allowed entries are collected, so
+# entries dropped by the status filter do not consume result slots.
 RESULTS=""
+result_count=0
 while IFS= read -r line; do
   filepath=${line#* }
   [ -n "$filepath" ] || continue
-  title=$(rg --no-filename '^title:' "$filepath" 2>/dev/null | head -1 | sed 's/^title:[[:space:]]*//' | tr -d '"')
+  # Read status / superseded_by from the frontmatter block only, so body
+  # text that happens to start a line with "status:" cannot leak in.
+  status=""
+  superseded_by=""
+  IFS=$'\t' read -r status superseded_by < <(awk '
+    { sub(/\r$/, "") }
+    NR == 1 { if ($0 != "---") exit; next }
+    $0 == "---" { exit }
+    sub(/^status:[[:space:]]*/, "")        { gsub(/"/, ""); sub(/[[:space:]]+$/, ""); s = $0 }
+    sub(/^superseded_by:[[:space:]]*/, "") { gsub(/"/, ""); sub(/[[:space:]]+$/, ""); sb = $0 }
+    END { printf "%s\t%s\n", s, sb }
+  ' "$filepath" 2>/dev/null) || true
+  status=${status:-active}
+  if [ "$ALLOWED_STATUS" != "all" ]; then
+    case ",${ALLOWED_STATUS}," in
+      *",${status},"*) ;;
+      *) continue ;;
+    esac
+  fi
+  # `|| true`: with pipefail a title-less file would otherwise abort the
+  # whole hook (rg exits 1), making the basename fallback unreachable.
+  title=$(rg --no-filename '^title:' "$filepath" 2>/dev/null | head -1 | sed 's/^title:[[:space:]]*//' | tr -d '"' || true)
   [ -n "$title" ] || title=$(basename "$filepath" .md)
-  RESULTS="${RESULTS}- ${title} (${filepath})"$'\n'
+  note=""
+  if [ "$status" != "active" ]; then
+    note=" [status: ${status}"
+    [ -n "$superseded_by" ] && note="${note}, superseded_by: ${superseded_by}"
+    note="${note}]"
+  fi
+  RESULTS="${RESULTS}- ${title} (${filepath})${note}"$'\n'
+  result_count=$((result_count + 1))
+  [ "$result_count" -lt "$MAX_RESULTS" ] || break
 done < <(
   for f in "${!file_scores[@]}"; do
     printf '%s %s\n' "${file_scores[$f]}" "$f"
-  done | sort -rn | head -"$MAX_RESULTS"
+  done | sort -rn
 )
 
 [ -n "$RESULTS" ] || exit 0

--- a/tests/test_knowledge_search_hook.py
+++ b/tests/test_knowledge_search_hook.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Self-tests for hooks/userpromptsubmit_knowledge_search.sh status filtering.
+
+Run: python3 tests/test_knowledge_search_hook.py   (exit 0 = all pass)
+
+The hook needs bash, jq and rg on PATH (its own runtime dependencies); mecab
+is replaced with a stub executable that emits fixed noun lines, so the tests
+are deterministic and do not require a mecab installation. All fixture
+entries are synthetic.
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+
+HOOK = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "hooks",
+    "userpromptsubmit_knowledge_search.sh",
+)
+
+MECAB_STUB = """#!/usr/bin/env bash
+# mecab stub: ignore stdin, emit fixed noun lines in mecab output format.
+cat >/dev/null
+printf 'alphaword\\t名詞,一般,*,*,*,*,*\\n'
+printf 'betaword\\t名詞,一般,*,*,*,*,*\\n'
+printf 'EOS\\n'
+"""
+
+
+def _make_workdir():
+    """Create a tempdir with an entries tree and a stubbed-mecab bin dir."""
+    workdir = tempfile.mkdtemp(prefix="ccmemo-ks-")
+    os.makedirs(os.path.join(workdir, ".claude", "knowledge", "entries", "2026"))
+    bindir = os.path.join(workdir, "stub-bin")
+    os.makedirs(bindir)
+    mecab = os.path.join(bindir, "mecab")
+    with open(mecab, "w", encoding="utf-8") as f:
+        f.write(MECAB_STUB)
+    os.chmod(mecab, os.stat(mecab).st_mode | stat.S_IXUSR)
+    return workdir, bindir
+
+
+def _write_entry(workdir, name, title, body, status=None, superseded_by=None):
+    lines = ["---", f'title: "{title}"']
+    if status is not None:
+        lines.append(f"status: {status}")
+    if superseded_by is not None:
+        lines.append(f"superseded_by: {superseded_by}")
+    lines += ["---", "", body, ""]
+    path = os.path.join(workdir, ".claude", "knowledge", "entries", "2026", name)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+
+
+def _run_hook(workdir, bindir, search_status=None):
+    """Run the hook in workdir; return (exit_code, additionalContext-or-'')."""
+    env = dict(os.environ)
+    env["PATH"] = bindir + os.pathsep + env.get("PATH", "")
+    env.pop("CCMEMO_SEARCH_STATUS", None)
+    if search_status is not None:
+        env["CCMEMO_SEARCH_STATUS"] = search_status
+    proc = subprocess.run(
+        ["bash", HOOK],
+        input=json.dumps({"prompt": "テスト prompt"}),
+        capture_output=True,
+        text=True,
+        cwd=workdir,
+        env=env,
+    )
+    if not proc.stdout.strip():
+        return proc.returncode, ""
+    payload = json.loads(proc.stdout)
+    return proc.returncode, payload["hookSpecificOutput"]["additionalContext"]
+
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"ok   {name}")
+    else:
+        print(f"FAIL {name}  {detail}")
+        FAILURES.append(name)
+
+
+def test_default_excludes_non_active():
+    workdir, bindir = _make_workdir()
+    try:
+        _write_entry(workdir, "a-active.md", "Active entry", "alphaword", status="active")
+        _write_entry(workdir, "b-superseded.md", "Old superseded entry", "alphaword",
+                     status="superseded", superseded_by="2026/a-active.md")
+        _write_entry(workdir, "c-deprecated.md", "Deprecated entry", "alphaword",
+                     status="deprecated")
+        code, ctx = _run_hook(workdir, bindir)
+        check("default: hook exits 0", code == 0, f"code={code}")
+        check("default: active surfaces", "Active entry" in ctx, ctx)
+        check("default: superseded excluded", "b-superseded.md" not in ctx, ctx)
+        check("default: deprecated excluded", "c-deprecated.md" not in ctx, ctx)
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_missing_status_treated_as_active():
+    workdir, bindir = _make_workdir()
+    try:
+        _write_entry(workdir, "nostatus.md", "Pre-status-era entry", "alphaword")
+        code, ctx = _run_hook(workdir, bindir)
+        check("no status line: still surfaces",
+              code == 0 and "Pre-status-era entry" in ctx, ctx)
+        check("no status line: no annotation", "[status:" not in ctx, ctx)
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_widened_allowlist_annotates():
+    workdir, bindir = _make_workdir()
+    try:
+        _write_entry(workdir, "a-active.md", "Active entry", "alphaword", status="active")
+        _write_entry(workdir, "b-superseded.md", "Old superseded entry", "alphaword",
+                     status="superseded", superseded_by="2026/a-active.md")
+        code, ctx = _run_hook(workdir, bindir, search_status="active,superseded")
+        check("widened: superseded surfaces", "Old superseded entry" in ctx, ctx)
+        check("widened: annotated with status and superseded_by",
+              "[status: superseded, superseded_by: 2026/a-active.md]" in ctx, ctx)
+        active_lines = [l for l in ctx.splitlines() if "Active entry" in l]
+        check("widened: active line not annotated",
+              active_lines and all("[status:" not in l for l in active_lines),
+              ctx)
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_all_disables_filter():
+    workdir, bindir = _make_workdir()
+    try:
+        _write_entry(workdir, "c-deprecated.md", "Deprecated entry", "alphaword",
+                     status="deprecated")
+        code, ctx = _run_hook(workdir, bindir, search_status="all")
+        check("all: deprecated surfaces", "Deprecated entry" in ctx, ctx)
+        check("all: annotated with bare status", "[status: deprecated]" in ctx, ctx)
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_filtered_entries_do_not_consume_slots():
+    workdir, bindir = _make_workdir()
+    try:
+        # The superseded entry matches both stub keywords, so it outranks the
+        # five active entries (which match only one). With the filter on, all
+        # five active entries must still surface (MAX_RESULTS=5): the dropped
+        # top hit must not consume a result slot.
+        _write_entry(workdir, "top-superseded.md", "Top-ranked superseded entry",
+                     "alphaword betaword", status="superseded",
+                     superseded_by="2026/active-1.md")
+        for i in range(1, 6):
+            _write_entry(workdir, f"active-{i}.md", f"Active entry {i}",
+                         "alphaword", status="active")
+        code, ctx = _run_hook(workdir, bindir)
+        missing = [i for i in range(1, 6) if f"Active entry {i}" not in ctx]
+        check("slots: all five active entries surface", not missing,
+              f"missing={missing} ctx={ctx}")
+        check("slots: superseded top hit excluded",
+              "Top-ranked superseded entry" not in ctx, ctx)
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_all_candidates_filtered_yields_no_output():
+    workdir, bindir = _make_workdir()
+    try:
+        _write_entry(workdir, "b-superseded.md", "Old superseded entry", "alphaword",
+                     status="superseded")
+        code, ctx = _run_hook(workdir, bindir)
+        check("all filtered: exits 0 with no injection", code == 0 and ctx == "",
+              f"code={code} ctx={ctx}")
+    finally:
+        shutil.rmtree(workdir)
+
+
+def test_body_status_line_does_not_leak():
+    workdir, bindir = _make_workdir()
+    try:
+        # "status:" at line start in the BODY must not be read as frontmatter.
+        _write_entry(workdir, "bodytrap.md", "Body mentions status",
+                     "alphaword\nstatus: superseded\n(quoted example, not frontmatter)")
+        code, ctx = _run_hook(workdir, bindir)
+        check("body status line ignored", "Body mentions status" in ctx, ctx)
+    finally:
+        shutil.rmtree(workdir)
+
+
+def main():
+    for tool in ("bash", "jq", "rg"):
+        if shutil.which(tool) is None:
+            print(f"skip: required tool not on PATH: {tool}")
+            return 0
+    test_default_excludes_non_active()
+    test_missing_status_treated_as_active()
+    test_widened_allowlist_annotates()
+    test_all_disables_filter()
+    test_filtered_entries_do_not_consume_slots()
+    test_all_candidates_filtered_yields_no_output()
+    test_body_status_line_does_not_leak()
+    if FAILURES:
+        print(f"\n{len(FAILURES)} failure(s): {', '.join(FAILURES)}")
+        return 1
+    print("\nall tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The per-prompt `UserPromptSubmit` auto-search hook ignores frontmatter `status`, so `superseded` / `deprecated` entries are injected into context as current knowledge. `scripts/kb_search.py` already has a `--status` filter and the entry templates define non-active statuses as reference-only — the always-on injection path was the one place that ignored the vocabulary, which silently breaks supersede-based knowledge-evolution workflows (the old entry keeps surfacing as if current).

## Fix

- Filter hits to a status allowlist, default `active`. Entries without a `status:` line still surface (pre-status-era entries keep working).
- The field is read from the frontmatter block only — a body line that happens to start with `status:` cannot leak in.
- Slot preservation: the hook walks the ranking until `MAX_RESULTS` allowed entries are collected, so a filtered-out top hit does not consume a result slot.
- `CCMEMO_SEARCH_STATUS`: comma-separated allowlist (e.g. `active,superseded`), `all` disables filtering. Non-active entries deliberately surfaced this way are annotated with `[status: …, superseded_by: …]` so the reader sees they are not current (drop by default, degrade when opted in).
- Drive-by fix: a title-less entry file aborted the whole hook (`rg` exits 1 under `pipefail`, making the `basename` fallback unreachable). Now guarded with `|| true`.

## Tests

`tests/test_knowledge_search_hook.py` (same dependency-free self-test style as the existing suite) runs the hook end-to-end with a stubbed `mecab`; 15 checks covering default exclusion, missing-status fallback, allowlist widening with annotation, `all`, slot preservation, silent no-op when everything is filtered, and frontmatter-only extraction. Full suite (6 test files) passes. Also smoke-tested against a real knowledge base: a superseded entry that previously ranked first is now excluded and the freed slot is filled by the next active entry.

## Docs

`docs/usage.md` / `docs/usage.ja.md` gain a Customization bullet for the filter (kept in sync), `docs/architecture.md` notes the hook stays rg-only but is now status-aware. CHANGELOG + version bump to 1.19.0.