### PR TITLE
feat: supersede helper and change-recording conventions — v1.20.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "author": {
     "name": "LevNas"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.20.0] - 2026-08-16
+
+### Added
+- `supersede <old> <new>` subcommand in `scripts/kb_graph.py`: the Change Flow
+  in one validated step — sets the `status: superseded` + `superseded_by:`
+  frontmatter pair, inserts a body-top warning banner
+  (`> **⚠ superseded (date)** — current: [title](id)`), and appends an
+  `- amends:` back-link to the replacement via the `link-add` machinery
+  (skipped when the replacement already links the old entry). Everything is
+  validated before anything is written (no partial application), re-running
+  completes an interrupted run, and self-supersede, conflicting successors,
+  supersede cycles, bracketed replacement titles and anchor-less replacements
+  are refused loudly. `--date` and `--dry-run` supported.
+- Tests: eight new checks in `tests/test_kb_graph.py` covering the frontmatter
+  pair, banner placement, back-link, lint-cleanliness of the result,
+  idempotent re-run and self-healing, cycle/conflict refusal, atomicity
+  without an anchor, dry-run, and bracket-title refusal.
+
+### Changed
+- `record-knowledge` procedure: the Correction Flow is generalized to a
+  **Change Flow** — supersede now explicitly covers evolved understanding, not
+  just corrections — and the Amendment Rules gained a decision table for
+  in-place edit vs `amends:`/`extends:` entry vs supersede, keyed on one
+  question: may the old entry still be cited as current knowledge afterwards?
+- Warning-banner convention documented for non-active entries (body-top
+  blockquote; deliberately not a list-form link so the lineage is not
+  double-booked as a graph edge), in the procedure and both distributed
+  `CLAUDE.md` templates. The banner is a human aid — machine paths already
+  respect `status` since 1.19.0.
+- `docs/link-graph.md`: `supersede` documented alongside `link-add`.
+
 ## [1.19.0] - 2026-08-16
 
 ### Fixed

--- a/docs/link-graph.md
+++ b/docs/link-graph.md
@@ -38,6 +38,7 @@ python3 scripts/kb_graph.py neighborhood <entry> --depth 2
 python3 scripts/kb_graph.py path <entry-a> <entry-b> # shortest link path
 python3 scripts/kb_graph.py lineage <entry>          # supersede chain → current authority
 python3 scripts/kb_graph.py link-add <src> <dst> --reason "why"  # deterministic writer
+python3 scripts/kb_graph.py supersede <old> <new> --reason "what changed"  # change flow
 python3 scripts/kb_graph.py lint                     # exit 1 on findings
 ```
 
@@ -76,6 +77,22 @@ so the caller can fall back to a manual edit. `--kind see|ref|amends|extends`
 either file; `--dry-run` prints the planned insertion. A target whose
 frontmatter title contains a square bracket is refused — the label would not
 parse back as a link (see `malformed-link`); rename the title instead.
+
+### `supersede <old> <new> --reason "..."`
+
+The Change Flow in one validated step: marks `old` as replaced by `new`. Sets
+the `status: superseded` + `superseded_by:` frontmatter pair on the old entry,
+inserts a body-top warning banner
+(`> **⚠ superseded (date)** — current: [title](id)`, `--date` overrides
+today), and appends an `- amends:` back-link to the replacement via the
+`link-add` machinery (skipped when the replacement already links the old
+entry). Every piece is validated before anything is written; the command is
+idempotent, so re-running completes an interrupted run and a fully applied
+state is reported as `already superseded`. Refused loudly: self-supersede, a
+conflicting existing successor, a supersede cycle, a bracketed replacement
+title, and a replacement with no link anchor (`--dry-run` previews). The
+banner is a blockquote on purpose — a list-form line would double-book the
+lineage as a graph edge.
 
 ### `lint [files...]`
 
@@ -128,8 +145,9 @@ by `lint` but are not part of the entry graph.
 ## How the skills use it
 
 - **`/record-knowledge`** — backlinks (step 7) and typed links are written with
-  `link-add` instead of hand-editing entry files; the Correction Flow's
-  successor-side back-link is an `amends:` link.
+  `link-add` instead of hand-editing entry files; the Change Flow's
+  frontmatter pair, banner and successor-side `amends:` back-link are applied
+  with `supersede`.
 - **`/recall-knowledge`** — multi-hop recalls (tracing how a decision evolved,
   connecting two topics, mapping an area) query `neighborhood` / `path` first
   and read only the endpoint entries, instead of chaining

--- a/scripts/kb_graph.py
+++ b/scripts/kb_graph.py
@@ -11,13 +11,15 @@ Subcommands:
   path <a> <b>           shortest link path between two entries
   lineage <entry>        supersede chain: what this replaced, what replaced it
   link-add <src> <dst>   deterministically append a typed link line to src
+  supersede <old> <new>  mark old as replaced by new: frontmatter pair,
+                         body-top banner, amends back-link — in one atomic step
   lint [files...]        deterministic checks (pre-commit friendly, exit 1 on findings)
 
 Edge kinds:
   see / ref              untyped association (list links, unchanged)
   amends / extends       typed list links: correction note / elaboration
   superseded_by          derived from the `superseded_by:` frontmatter field
-                         (correction flow) — old entry -> replacement, max one
+                         (change flow) — old entry -> replacement, max one
                          per entry, entries-root-relative path only
 
 Output contains entry IDs, titles and edge types only — never body text —
@@ -54,6 +56,7 @@ pre-commit example (fires only when staged entries changed):
 """
 
 import argparse
+import datetime
 import json
 import os
 import re
@@ -517,6 +520,101 @@ def cmd_link_add(root, nodes, args):
             print(f"linked: {s} -> {d}")
 
 
+BANNER_MARK = "> **⚠ superseded"
+
+
+def cmd_supersede(root, nodes, edges, args):
+    """Mark old as replaced by new: frontmatter pair + banner + back-link.
+
+    All three pieces are validated before anything is written, and each is
+    skipped when already present, so an interrupted run can simply be re-run
+    (idempotent completion). Exits non-zero on any ambiguity.
+    """
+    old = resolve_entry(nodes, args.old)
+    new = resolve_entry(nodes, args.new)
+    root_abs = os.path.abspath(root)
+    if old == new:
+        sys.exit("error: refusing to supersede an entry with itself")
+    new_title = nodes[new]["title"]
+    if not new_title:
+        sys.exit(f"error: replacement entry has no frontmatter title: {new}")
+    if "[" in new_title or "]" in new_title:
+        sys.exit(f"error: title of {new} contains a square bracket — the banner "
+                 "link label would not parse; rename the title first")
+
+    # A superseded_by chain from the replacement must not lead back to the
+    # old entry — that would create a supersede cycle.
+    nxt, _prevs = supersede_maps(edges)
+    cur, hops = new, 0
+    while cur in nxt and hops <= len(nxt):
+        cur = nxt[cur]
+        hops += 1
+        if cur == old:
+            sys.exit(f"error: {new} is (transitively) superseded by {old} — "
+                     "refusing to create a supersede cycle")
+
+    old_path = os.path.join(root_abs, old)
+    with open(old_path, encoding="utf-8") as f:
+        old_text = f.read()
+    meta = parse_frontmatter(old_text)
+    if not meta:
+        sys.exit(f"error: old entry has no frontmatter: {old}")
+    existing = meta.get("superseded_by", "")
+    if existing and existing != new:
+        sys.exit(f"error: {old} is already superseded by {existing} — "
+                 "refusing to overwrite; resolve the lineage manually")
+
+    plans = []  # (path, new_text, done_message)
+
+    updated = old_text
+    # 1) Frontmatter: status + superseded_by as an adjacent pair.
+    if meta.get("status") != "superseded" or existing != new:
+        fm_end = updated.find("\n---", 3)
+        head, rebuilt, inserted = updated[:fm_end].splitlines(), [], False
+        for ln in head:
+            if re.match(r"^superseded_by:\s*", ln):
+                continue
+            if re.match(r"^status:\s*", ln):
+                rebuilt.append("status: superseded")
+                rebuilt.append(f"superseded_by: {new}")
+                inserted = True
+            else:
+                rebuilt.append(ln)
+        if not inserted:
+            rebuilt.append("status: superseded")
+            rebuilt.append(f"superseded_by: {new}")
+        updated = "\n".join(rebuilt) + updated[fm_end:]
+    # 2) Body-top warning banner, directly under the closing delimiter.
+    if BANNER_MARK not in updated:
+        fm_end = updated.find("\n---", 3)
+        nl = updated.find("\n", fm_end + 1)
+        if nl == -1:
+            updated += "\n"
+            nl = len(updated) - 1
+        banner = (f"\n{BANNER_MARK} ({args.date})** — current: "
+                  f"[{new_title}]({new})\n")
+        updated = updated[:nl + 1] + banner + updated[nl + 1:]
+    if updated != old_text:
+        plans.append((old_path, updated, f"marked superseded: {old} -> {new}"))
+
+    # 3) amends back-link in the replacement (validated before any write;
+    #    plan_link exits non-zero on a missing anchor or bracketed old title).
+    link_plan = plan_link(root_abs, nodes, new, old, "amends", args.reason)
+    if link_plan:
+        path, text, line = link_plan
+        plans.append((path, text, f"back-linked: {new} -> {old}\n  {line.rstrip()}"))
+
+    if not plans:
+        print(f"already superseded: {old} -> {new} (banner and back-link present)")
+        return
+    for path, text, message in plans:
+        if args.dry_run:
+            print(f"dry-run: would have {message}")
+        else:
+            _write_atomic(path, text)
+            print(message)
+
+
 def main():
     p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
     p.add_argument("--root", default=".claude/knowledge/entries",
@@ -544,6 +642,15 @@ def main():
                     help="reason for the reverse link (default: --reason)")
     la.add_argument("--dry-run", action="store_true",
                     help="print planned insertions without writing")
+    sp = sub.add_parser("supersede")
+    sp.add_argument("old", help="entry being replaced (unique filename substring)")
+    sp.add_argument("new", help="replacement entry")
+    sp.add_argument("--reason", required=True,
+                    help="what the replacement changes (amends back-link text)")
+    sp.add_argument("--date", default=None,
+                    help="banner date, YYYY-MM-DD (default: today)")
+    sp.add_argument("--dry-run", action="store_true",
+                    help="print planned changes without writing")
     li = sub.add_parser("lint")
     li.add_argument("files", nargs="*",
                     help="limit findings to these files (e.g. staged entries)")
@@ -565,6 +672,10 @@ def main():
         cmd_lineage(nodes, edges, resolve_entry(nodes, args.entry), args.json)
     elif args.cmd == "link-add":
         cmd_link_add(args.root, nodes, args)
+    elif args.cmd == "supersede":
+        if args.date is None:
+            args.date = datetime.date.today().isoformat()
+        cmd_supersede(args.root, nodes, edges, args)
     elif args.cmd == "lint":
         registry = args.registry or os.path.join(args.root, "..", "CLAUDE.md")
         cmd_lint(nodes, edges, problems, registry, args.files, args.json)

--- a/skills/record-knowledge/assets/knowledge-CLAUDE.md
+++ b/skills/record-knowledge/assets/knowledge-CLAUDE.md
@@ -51,6 +51,8 @@ Add new tags here. Reuse existing tags when possible.
 | `superseded` | Replaced by newer entry — follow `superseded_by` link |
 | `deprecated` | Obsolete, no longer relevant |
 
+Non-active entries carry a body-top warning banner so direct readers see the state first, e.g. `> **⚠ superseded (YYYY-MM-DD)** — current: [replacement title](YYYY/MM/slug.md)`.
+
 ### Type
 | Type | Meaning |
 |------|---------|

--- a/skills/record-knowledge/procedure.md
+++ b/skills/record-knowledge/procedure.md
@@ -107,7 +107,7 @@ Two typed list links carry lineage semantics that plain `see:` does not; `kb_gra
 
 | Kind | Meaning | Use when |
 |------|---------|----------|
-| `amends:` | Correction / addendum note | This entry corrects or supplements part of the target **without replacing it** — and, in the Correction Flow, the replacement entry pointing back at the entry it supersedes |
+| `amends:` | Correction / addendum note | This entry corrects or supplements part of the target **without replacing it** — and, in the Change Flow, the replacement entry pointing back at the entry it supersedes |
 | `extends:` | Elaboration | This entry develops, specializes, or builds on the target |
 
 - When neither applies, use plain `see:` — the typed vocabulary is deliberately minimal
@@ -131,17 +131,54 @@ Two typed list links carry lineage semantics that plain `see:` does not; `kb_gra
 | `mid` | Reproduced or confirmed in some contexts |
 | `high` | Verified multiple times, well-established |
 
-### Correction Flow (superseded)
-1. Set `status: superseded` and add `superseded_by: YYYY/MM/newer-entry-slug.md` (entries/-relative path)
-2. Create the replacement entry with an `- amends:` back-link: `- amends: [original title](YYYY/MM/original.md) — what was corrected`
-3. Keep the original entry intact
+### Change Flow (supersede)
 
-`kb_graph.py lint` enforces the frontmatter pair deterministically (`superseded-status-mismatch`, `superseded-broken`, `superseded-missing-successor`, `supersede-cycle`).
+Use when the Amendment Rules below say **supersede**: the change is not just a correction — the conclusion, policy, or understanding is updated and readers should no longer follow the old entry.
 
-## Amendment Rules
-- Entries are **mutable** — edit in place (git tracks change history)
-- Use `deprecated` only when knowledge is genuinely obsolete
-- Use `superseded` when an entry is replaced by a corrected version
+1. Create the replacement entry first (normal recording flow)
+2. Run the bundled helper — it applies every mechanical piece in one validated step:
+
+   ```bash
+   python3 "<plugin_root>/scripts/kb_graph.py" --root .claude/knowledge/entries \
+     supersede <old-entry-filename> <new-entry-filename> \
+     --reason "<what the replacement changes>"
+   ```
+
+   It sets the `status: superseded` + `superseded_by:` frontmatter pair on the old entry, inserts the body-top warning banner (next section), and appends an `- amends:` back-link to the replacement (skipped when the replacement already links the old entry). Everything is validated before anything is written, and re-running is safe — an interrupted run is completed. On a non-zero exit (ambiguous name, bracketed title, no link anchor, conflicting successor), fall back to the manual steps:
+   - Old entry: set `status: superseded`, add `superseded_by: YYYY/MM/newer-entry-slug.md` (entries/-relative path)
+   - Old entry: insert the warning banner directly under the frontmatter
+   - Replacement: add `- amends: [original title](YYYY/MM/original.md) — what changed`
+3. Keep the original entry body intact otherwise — supersede is a status change plus banner, not an edit
+
+`kb_graph.py lint` enforces the frontmatter pair deterministically (`superseded-status-mismatch`, `superseded-broken`, `superseded-missing-successor`, `supersede-cycle`); `kb_graph.py lineage` resolves chains to the current authority.
+
+### Warning Banner (superseded / deprecated)
+
+Non-active entries carry a banner as the first body line, so a human opening the file directly (editor, code hosting) sees the state before the content:
+
+```markdown
+> **⚠ superseded (YYYY-MM-DD)** — current: [replacement title](YYYY/MM/slug.md)
+```
+
+For `deprecated` (obsolete without a replacement): `> **⚠ deprecated (YYYY-MM-DD)** — <why it no longer applies>`
+
+The banner is a human aid — machine paths already respect `status` (the per-prompt auto-search hook filters non-active entries, dedup scans skip them). Keep it a blockquote: it must NOT be a `- see:`-style list line, or it would double-book the lineage as a graph edge.
+
+## Amendment Rules (in-place vs new entry vs supersede)
+
+Entries are **mutable** — in-place editing is the default, and git tracks history. When knowledge *changes*, pick the recording form with one question: **may the old entry still be cited as current knowledge afterwards?**
+
+| Change | Old still current? | Action |
+|--------|--------------------|--------|
+| Correction — typos, broken links, wording | yes | Edit in place |
+| Reinforcement — sources/examples added; conclusion and confidence unchanged | yes | Edit in place |
+| Partial correction / addendum note on the target | yes | New entry + `- amends:` link; old stays `active` |
+| Elaboration / specialization building on the target | yes | New entry + `- extends:` link; old stays `active` |
+| Evolution / replacement — conclusion, policy, or understanding updated | **no** | New entry + Change Flow (supersede) above |
+
+- Superseding on every edit shatters a topic into time slices; in-place editing a changed conclusion hides the change from readers. The question above is the boundary.
+- Use `deprecated` only when knowledge is genuinely obsolete **without** a replacement; when there is a replacement, supersede.
+- Not retroactive: do not reshape existing entries wholesale — apply the rule from the next change onward.
 
 ## Entry Granularity
 **1 entry = 1 topic.** Splitting guidelines:

--- a/templates/knowledge/CLAUDE.md
+++ b/templates/knowledge/CLAUDE.md
@@ -65,6 +65,8 @@ Add new tags here. Reuse existing tags when possible.
 | `superseded` | Replaced by newer entry — follow `superseded_by` link |
 | `deprecated` | Obsolete, no longer relevant |
 
+Non-active entries carry a body-top warning banner so direct readers see the state first, e.g. `> **⚠ superseded (YYYY-MM-DD)** — current: [replacement title](YYYY/MM/slug.md)`.
+
 ### Type
 | Type | Meaning |
 |------|---------|

--- a/tests/test_kb_graph.py
+++ b/tests/test_kb_graph.py
@@ -500,6 +500,118 @@ Body G.
         assert read(root, ENTRY_G) == before_g and read(root, ENTRY_B) == before
 
 
+def test_supersede_marks_frontmatter_banner_and_backlink():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        add_entry_e(root)
+        res = run_cli(root, "supersede", "topic-a", "section-only-e",
+                      "--reason", "replaced by consolidated entry",
+                      "--date", "2026-08-16")
+        assert res.returncode == 0, (res.stdout, res.stderr)
+        text_a = read(root, ENTRY_A)
+        # status/superseded_by as an adjacent frontmatter pair, old status gone
+        assert f"status: superseded\nsuperseded_by: {ENTRY_E}\n" in text_a, text_a
+        assert "status: active" not in text_a, text_a
+        # banner directly under the closing frontmatter delimiter
+        banner = (f"> **⚠ superseded (2026-08-16)** — current: "
+                  f"[Section Only E]({ENTRY_E})")
+        assert f"---\n\n{banner}\n" in text_a, text_a
+        # amends back-link appended to the replacement (heading anchor)
+        line = f"- amends: [Topic A]({ENTRY_A}) — replaced by consolidated entry"
+        assert line in read(root, ENTRY_E), read(root, ENTRY_E)
+        # the result must not trip any supersede lint check
+        res = run_cli(root, "lint")
+        assert "superseded-" not in res.stdout and "supersede-" not in res.stdout, res.stdout
+
+
+def test_supersede_existing_see_link_counts_as_backlink():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        # fixture B already carries "- see: [Topic A]" -> no amends duplicate
+        before_b = read(root, ENTRY_B)
+        res = run_cli(root, "supersede", "topic-a", "topic-b",
+                      "--reason", "r", "--date", "2026-08-16")
+        assert res.returncode == 0, (res.stdout, res.stderr)
+        assert "already linked" in res.stdout, res.stdout
+        assert read(root, ENTRY_B) == before_b, "no near-duplicate link line"
+        assert "status: superseded" in read(root, ENTRY_A)
+
+
+def test_supersede_is_idempotent_and_self_healing():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        add_entry_e(root)
+        args = ("supersede", "topic-a", "section-only-e",
+                "--reason", "r", "--date", "2026-08-16")
+        assert run_cli(root, *args).returncode == 0
+        after_a, after_e = read(root, ENTRY_A), read(root, ENTRY_E)
+        # full rerun: recognised, nothing rewritten
+        res = run_cli(root, *args)
+        assert res.returncode == 0 and "already superseded" in res.stdout, res.stdout
+        assert read(root, ENTRY_A) == after_a and read(root, ENTRY_E) == after_e
+        # interrupted-run repair: back-link missing -> only that piece is redone
+        stripped = "\n".join(l for l in after_e.splitlines()
+                             if "- amends:" not in l) + "\n"
+        with open(os.path.join(root, ENTRY_E), "w", encoding="utf-8") as f:
+            f.write(stripped)
+        res = run_cli(root, *args)
+        assert res.returncode == 0 and "back-linked" in res.stdout, res.stdout
+        assert read(root, ENTRY_A) == after_a, "old entry must stay untouched"
+        assert read(root, ENTRY_E).count("- amends:") == 1
+
+
+def test_supersede_refuses_cycle_and_conflicting_successor():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        assert run_cli(root, "supersede", "topic-a", "topic-b",
+                       "--reason", "r", "--date", "2026-08-16").returncode == 0
+        # reverse direction would close a cycle
+        res = run_cli(root, "supersede", "topic-b", "topic-a",
+                      "--reason", "r", "--date", "2026-08-16")
+        assert res.returncode != 0 and "cycle" in res.stderr, res.stderr
+        # a second, different successor must not silently overwrite the first
+        before_a = read(root, ENTRY_A)
+        res = run_cli(root, "supersede", "topic-a", "orphan-c",
+                      "--reason", "r", "--date", "2026-08-16")
+        assert res.returncode != 0 and "already superseded by" in res.stderr, res.stderr
+        assert read(root, ENTRY_A) == before_a
+
+
+def test_supersede_no_partial_application_without_backlink_anchor():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        before_a = read(root, ENTRY_A)
+        # orphan-c has no link line and no 関連 heading -> back-link cannot be
+        # planned -> the old entry must not be written either
+        res = run_cli(root, "supersede", "topic-a", "orphan-c",
+                      "--reason", "r", "--date", "2026-08-16")
+        assert res.returncode != 0 and "manually" in res.stderr, res.stderr
+        assert read(root, ENTRY_A) == before_a, "no partial application"
+
+
+def test_supersede_dry_run_writes_nothing():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        before_a, before_b = read(root, ENTRY_A), read(root, ENTRY_B)
+        res = run_cli(root, "supersede", "topic-a", "topic-b",
+                      "--reason", "r", "--date", "2026-08-16", "--dry-run")
+        assert res.returncode == 0 and "dry-run" in res.stdout, res.stdout
+        assert read(root, ENTRY_A) == before_a and read(root, ENTRY_B) == before_b
+
+
+def test_supersede_refuses_bracket_replacement_title():
+    with tempfile.TemporaryDirectory() as base:
+        root = make_kb(base)
+        with open(os.path.join(root, ENTRY_G), "w", encoding="utf-8") as f:
+            f.write('---\ntitle: Guide [draft]\ncreated: 2026-07-05\n'
+                    'status: active\ntags: "#pitfall"\n---\n\nBody G.\n\n## 関連\n\n')
+        before_a = read(root, ENTRY_A)
+        res = run_cli(root, "supersede", "topic-a", "bracket-g",
+                      "--reason", "r", "--date", "2026-08-16")
+        assert res.returncode != 0 and "square bracket" in res.stderr, res.stderr
+        assert read(root, ENTRY_A) == before_a
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
## Problem

The record-knowledge procedure had the supersede vocabulary and a minimal Correction Flow, but three gaps remained on the writer side:

1. **No boundary rule** between in-place editing ("entries are mutable") and superseding — per-edit superseding shatters a topic into time slices, while always editing in place hides changes from readers.
2. **Supersede framed as correction only** — evolved understanding (the conclusion or policy is updated) had no explicit home.
3. **No banner convention** — a human opening a superseded/deprecated file directly (editor, code hosting) had no in-body signal that the entry is not current. Machine paths already respect `status` since 1.19.0; the direct-read path did not.

The mechanical supersede steps (frontmatter pair + banner + back-link) were also easy to half-apply by hand — the existing supersede lints catch the frontmatter half, but a forgotten banner or back-link stayed silent.

## Changes

- **Amendment Rules decision table** in `skills/record-knowledge/procedure.md`, keyed on one question: *may the old entry still be cited as current knowledge afterwards?* Yes → in-place, or a new `amends:`/`extends:` entry with the old one staying active; no → Change Flow (supersede).
- **Correction Flow → Change Flow**: supersede explicitly covers evolved understanding, not only corrections.
- **Warning-banner convention**: non-active entries carry a body-top blockquote banner (`> **⚠ superseded (date)** — current: [title](id)`); documented in the procedure and both distributed `CLAUDE.md` templates. Deliberately a blockquote, not a list-form link — the lineage stays single-sourced in `superseded_by:` and is not double-booked as a graph edge.
- **`kb_graph.py supersede <old> <new> --reason "..."`**: the Change Flow in one validated step — frontmatter pair, banner, and `- amends:` back-link via the existing `link-add` machinery (skipped when the replacement already links the old entry). Validates everything before writing anything (no partial application), idempotent (re-running completes an interrupted run), refuses self-supersede, conflicting successors, supersede cycles, bracketed replacement titles, and anchor-less replacements. `--date` / `--dry-run` supported.

## Tests

Eight new checks in `tests/test_kb_graph.py` (26/26 pass; full 6-file suite green): frontmatter pair + banner placement + back-link, lint-cleanliness of the result, existing see-link counted as back-link (no near-duplicate), idempotent re-run and self-healing of a stripped back-link, cycle and conflicting-successor refusal, atomicity when the replacement has no link anchor, dry-run, bracket-title refusal. Also smoke-tested read-only (`--dry-run`) against a real knowledge base: an already-superseded pair was recognized, the existing back-link was skipped, and only the missing banner was planned.