### PR TITLE
fix: op:// redaction adjacent-syntax mangling, keep-names opt-in, consumer pre-commit wiring docs — v1.21.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "author": {
     "name": "LevNas"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.21.0] - 2026-08-16
+
+### Fixed
+- The `op://` redaction pattern no longer swallows adjacent syntax. The
+  greedy `\S+` consumed the closing quote, backtick or paren right after a
+  reference (`{{ onepasswordRead "op://…" | trim }}` lost its closing quote;
+  `` `op://` `` lost its closing backtick), mangling entry bodies on every
+  re-edit. The pattern now matches only the URI charset and must end on an
+  alphanumeric, so it stops at quotes, brackets, CJK text and trailing
+  punctuation. Applies to every redaction surface (entry profile, structured
+  args, free text); a deliberate, documented deviation from the shared TS
+  SPEC pattern.
+
+### Added
+- `CCMEMO_REDACT_OP_REF=keep-names`: the entry redact hook keeps `op://`
+  item-name references (`op://vault/item-name/field` — no secret value; a
+  host secrets policy may explicitly allow them) and masks only references
+  containing a raw 26-character item/vault ID segment. Default unchanged:
+  every `op://` reference is masked.
+- Tests: adjacent-syntax preservation (quote/backtick/paren), keep-names
+  name-vs-raw-ID split, unchanged default behaviour.
+
+### Changed
+- `docs/link-graph.md`: the pre-commit lint section now documents wiring for
+  a **consuming** repository. Pointing a hook at the version-keyed plugin
+  cache path freezes the lint on an old copy after every update and dies
+  silently once the cache is cleared; the docs now recommend a repo-committed
+  copy with loud skip paths, with a fail-loud newest-cache-copy resolver as
+  the alternative. The in-repo snippet in `scripts/kb_graph.py` carries a
+  matching warning.
+
 ## [1.20.0] - 2026-08-16
 
 ### Added

--- a/docs/link-graph.md
+++ b/docs/link-graph.md
@@ -122,6 +122,47 @@ changed=$(git diff --cached --name-only -- .claude/knowledge/entries/)
 [ -z "$changed" ] || python3 scripts/kb_graph.py lint $changed
 ```
 
+That snippet resolves `scripts/kb_graph.py` and therefore only works inside
+this repository — a consuming repository needs one of the wirings below.
+
+### Wiring the lint into a consuming repository
+
+A git hook runs outside Claude Code, and the plugin cache path is
+version-keyed (`…/plugins/cache/<marketplace>/ccmemo/<version>/scripts/kb_graph.py`).
+Do **not** point a hook at that path: after every plugin update it keeps
+running the old frozen copy (old versions stay in the cache, so nothing
+errors), and when the cache is eventually cleared the hook dies — silently,
+if the hook skips on a missing script. Neither failure announces itself.
+
+**Recommended — commit a copy into the repository.** Copy
+`scripts/kb_graph.py` from the plugin into the repo at any stable path,
+point the hook at it, and update the copy deliberately when a release
+changes lint behaviour (release notes call that out). Every clone and
+machine then gets the same lint with the repo, plugin installed or not:
+
+```sh
+#!/bin/sh
+changed=$(git diff --cached --name-only --diff-filter=d -- .claude/knowledge/entries/)
+[ -z "$changed" ] && exit 0
+command -v python3 >/dev/null 2>&1 || { echo "kb-lint: python3 not found, skipping" >&2; exit 0; }
+lint=tools/kb_graph.py   # repo-committed copy
+[ -f "$lint" ] || { echo "kb-lint: $lint not found, skipping" >&2; exit 0; }
+exec python3 "$lint" lint $changed
+```
+
+Keep the skip paths loud (write to stderr): a gate that skips silently is the
+worst failure mode — nothing lints and nothing tells you.
+
+**Alternative — resolve the newest cache copy, fail loudly.** To track the
+plugin automatically instead, glob the cache for the newest version and
+refuse to continue when none is found (rather than skipping):
+
+```sh
+lint=$(ls -d "$HOME"/.claude/plugins/cache/*/ccmemo/*/scripts/kb_graph.py 2>/dev/null | sort -V | tail -1)
+[ -n "$lint" ] || { echo "kb-lint: no plugin cache copy found — install ccmemo or commit a copy" >&2; exit 1; }
+exec python3 "$lint" lint $changed
+```
+
 ## Addressing entries
 
 Every subcommand that takes an entry accepts its path relative to the entries

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -84,6 +84,7 @@ Python 標準ライブラリだけで動き、索引も要りません。
 - **著者**：エントリの `author` フィールドの既定は `@<ユーザー名>` です。Git ホスティングのユーザー名に設定します。
 - **ワークフロー**：`skills/*/SKILL.md` を編集すると、プロジェクト固有の規約（タグの分類、イシューコメントの書式、プランのテンプレート）を足せます。
 - **自動コミット（オプトイン、既定はオフ）**：`CCMEMO_AUTOCOMMIT=1` を設定すると、セーフティネットのフックがセッション終了時（`SessionEnd`）と compaction の前（`PreCompact`）に、`.claude/knowledge/` と `.claude/tasks/` の変更だけをコミットします。`git add -A` は実行せず、push もしません。漏えいしやすい形が差分に含まれる場合は leak-scan ゲートがコミットを止めます（`CCMEMO_AUTOCOMMIT_ON_LEAK=warn` にすると警告つきでコミットします）。これは手動のセッション終了コミットの置き換えではなく補完なので、すでにコミット済みなら何もしません。
+- **redact フックの `op://` の扱い**：エントリの redact フックは既定で `op://` 参照をすべてマスクします。`CCMEMO_REDACT_OP_REF=keep-names` を設定すると、項目名参照（`op://vault/項目名/field`。秘密の実値を含まない）は残し、26 文字の生 ID 形式セグメントを含む参照だけをマスクします。
 - **自動検索の status フィルタ**：毎プロンプトの `UserPromptSubmit` フックは、frontmatter の `status` が `active` のエントリだけを注入します（`status:` 行が無いエントリは active 扱い）。`CCMEMO_SEARCH_STATUS` にカンマ区切りの許可リスト（例：`active,superseded`）を設定すると広げられ、`all` でフィルタを無効化できます。この経路で表に出た非 active エントリには `[status: …, superseded_by: …]` の注記が付くため、現行の知識と取り違えることはありません。
 
 ## Git リポジトリに置く理由

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,6 +108,10 @@ entries before starting work. Patterns and examples:
   to commit with a warning instead). It complements — does not replace — your
   manual end-of-session commit, so it is a no-op when you have already
   committed.
+- **Redact hook `op://` handling** — the entry redact hook masks every
+  `op://` reference by default. Set `CCMEMO_REDACT_OP_REF=keep-names` to keep
+  item-name references (`op://vault/item-name/field` — no secret value) and
+  mask only references containing a raw 26-character item/vault ID segment.
 - **Auto-search status filter** — the per-prompt `UserPromptSubmit` hook only
   injects entries whose frontmatter `status` is `active` (entries without a
   `status:` line count as active). Set `CCMEMO_SEARCH_STATUS` to a

--- a/hooks/lib/redact.py
+++ b/hooks/lib/redact.py
@@ -48,7 +48,12 @@ SENSITIVE_KEYS = (
 )
 
 # --- Value patterns (regex literals ported verbatim from the TS母体) ----------
-OP_REF = re.compile(r"\bop://\S+", re.IGNORECASE)
+# OP_REF deviates from the TS母体's `op://\S+` on purpose: the greedy \S+ ate
+# adjacent syntax (a closing quote, backtick or paren right after the URI),
+# mangling the surrounding text. Matching only the URI charset and requiring
+# the match to end on an alphanumeric stops it at quotes, brackets, CJK text
+# and trailing punctuation.
+OP_REF = re.compile(r"\bop://[A-Za-z0-9._~%/-]*[A-Za-z0-9]", re.IGNORECASE)
 JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}")
 PEM = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
 GH_TOKEN = re.compile(r"\bgh[pousr]_[A-Za-z0-9]{30,}\b")
@@ -67,6 +72,16 @@ ENTRY_SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     ("github-token", GH_TOKEN),
     ("email", EMAIL),
 )
+
+
+# 1Password item/vault IDs are 26-char lowercase alphanumeric strings. Item
+# NAME references (op://vault/item-name/field) carry no secret value, and a
+# host policy may explicitly allow them (CCMEMO_REDACT_OP_REF=keep-names).
+_OP_RAW_ID = re.compile(r"^[a-z0-9]{26}$")
+
+
+def _op_ref_contains_raw_id(ref: str) -> bool:
+    return any(_OP_RAW_ID.fullmatch(seg) for seg in ref[len("op://"):].split("/"))
 
 
 def _is_noreply(email: str) -> bool:
@@ -135,12 +150,18 @@ def redact_free_text(text: str, mode: str = "length") -> str:
     return f"{PLACEHOLDER} len={len(text)}"
 
 
-def redact_secrets_in_text(text: str) -> tuple[str, list[tuple[str, int]]]:
+def redact_secrets_in_text(
+    text: str, op_ref_mode: str = "mask-all"
+) -> tuple[str, list[tuple[str, int]]]:
     """Mask unambiguous secret *values* in a knowledge entry body.
 
     The entry profile: only the SPEC patterns that are unambiguous secrets
     (op://, JWT, PEM, GitHub token, non-noreply email). High-entropy is
     excluded to avoid clobbering git SHAs / long paths / base64 examples.
+
+    op_ref_mode: "mask-all" (default) masks every ``op://`` reference;
+    "keep-names" keeps item-name references and masks only those containing
+    a raw 26-character item/vault ID segment.
 
     Returns (new_text, hits) where hits is a list of (kind, count). When no
     secret is found, new_text is the input unchanged and hits is empty.
@@ -148,7 +169,20 @@ def redact_secrets_in_text(text: str) -> tuple[str, list[tuple[str, int]]]:
     hits: list[tuple[str, int]] = []
     result = text
     for kind, pattern in ENTRY_SECRET_PATTERNS:
-        if kind == "email":
+        if kind == "op-ref" and op_ref_mode == "keep-names":
+            count = 0
+
+            def _mask_op_ref(m: re.Match[str]) -> str:
+                nonlocal count
+                if not _op_ref_contains_raw_id(m.group(0)):
+                    return m.group(0)
+                count += 1
+                return PLACEHOLDER
+
+            result = pattern.sub(_mask_op_ref, result)
+            if count:
+                hits.append((kind, count))
+        elif kind == "email":
             count = 0
 
             def _mask_email(m: re.Match[str]) -> str:

--- a/hooks/postwrite_redact_entries.py
+++ b/hooks/postwrite_redact_entries.py
@@ -53,8 +53,13 @@ def main() -> None:
     except OSError:
         return
 
-    # 1. Redact unambiguous secret values in place.
-    redacted, hits = redact.redact_secrets_in_text(content)
+    # 1. Redact unambiguous secret values in place. CCMEMO_REDACT_OP_REF=
+    # keep-names lets a host policy keep op:// item-name references (no
+    # secret value) while still masking raw 26-char item/vault IDs.
+    op_ref_mode = ("keep-names"
+                   if os.environ.get("CCMEMO_REDACT_OP_REF") == "keep-names"
+                   else "mask-all")
+    redacted, hits = redact.redact_secrets_in_text(content, op_ref_mode=op_ref_mode)
     if hits:
         try:
             with open(file_path, "w", encoding="utf-8") as f:

--- a/scripts/kb_graph.py
+++ b/scripts/kb_graph.py
@@ -53,6 +53,8 @@ machine-readable output. `--root` points at the entries dir
 pre-commit example (fires only when staged entries changed):
     changed=$(git diff --cached --name-only -- .claude/knowledge/entries/)
     [ -z "$changed" ] || python3 scripts/kb_graph.py lint $changed
+(inside this repo only — a CONSUMING repo must not point a hook at the
+version-keyed plugin cache path; see docs/link-graph.md for the wiring)
 """
 
 import argparse

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -123,6 +123,31 @@ def test_leak_scan_repo_name_from_env():
             os.environ[key] = prev
 
 
+def test_redact_op_ref_stops_at_adjacent_syntax():
+    # The greedy `op://\S+` used to eat the closing quote / backtick / paren.
+    text = ('cfg: {{ onepasswordRead "op://Personal/some-item/field" | trim }}\n'
+            "inline `op://Personal/some-item/field` and (op://Personal/some-item/field).\n")
+    out, hits = redact.redact_secrets_in_text(text)
+    assert hits == [("op-ref", 3)], hits
+    assert f'"{PH}" | trim' in out, out
+    assert f"`{PH}`" in out, out
+    assert f"({PH})." in out, out
+
+
+def test_redact_op_ref_keep_names_mode():
+    named = "op://Personal/git-config/email"
+    raw = "op://Personal/abcdefghijklmnopqrstuvwxyz/token"  # 26-char raw ID segment
+    text = f"- {named}\n- {raw}\n"
+    out, hits = redact.redact_secrets_in_text(text, op_ref_mode="keep-names")
+    assert named in out, "item-name reference must survive keep-names"
+    assert raw not in out and PH in out, out
+    assert hits == [("op-ref", 1)], hits
+    # default mode is unchanged: both are masked
+    out2, hits2 = redact.redact_secrets_in_text(text)
+    assert named not in out2 and raw not in out2
+    assert hits2 == [("op-ref", 2)], hits2
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
## Problem 1 — redact hook mangles text around `op://` references

`OP_REF = r"\bop://\S+"`: the greedy `\S+` eats the closing quote, backtick or paren right after a reference, so re-editing an entry that legitimately documents `op://` usage breaks its own examples — `{{ onepasswordRead "op://…" | trim }}` loses the closing quote, `` `op://` `` loses the closing backtick. Additionally, host secrets policies may explicitly distinguish **item-name references** (`op://vault/item-name/field`, no secret value) from **raw item/vault IDs**, but the hook masks both indiscriminately, forcing manual restores on every re-edit of affected entries.

## Problem 2 — consumer pre-commit wiring is unspecified

The docs pre-commit snippet resolves `scripts/kb_graph.py`, which only exists inside this repository. A consuming repository improvising the path naturally lands on the plugin cache — which is **version-keyed**, producing a two-stage silent failure: after each plugin update the hook keeps running the old frozen copy (old versions remain in the cache, nothing errors), and once the cache is cleared the hook dies — silently, if wired to skip on a missing script.

## Changes

- `OP_REF` matches only the URI charset and must end on an alphanumeric — stops at quotes, backticks, brackets, CJK text and trailing punctuation. Deliberate, documented deviation from the shared TS SPEC pattern; applies to all redaction surfaces.
- `CCMEMO_REDACT_OP_REF=keep-names` (entry profile only): keep item-name references, mask only references containing a raw 26-character item/vault ID segment. Default unchanged — every `op://` reference is masked. Documented in usage en/ja.
- `docs/link-graph.md`: consumer wiring section — recommended repo-committed copy with loud skip paths; fail-loud newest-cache-copy resolver as the alternative; explicit warning against pointing a hook at the cache path (matching note in the `kb_graph.py` docstring).

## Tests

`test_policy.py` 10/10 (2 new: adjacent-syntax preservation incl. quote/backtick/paren; keep-names name-vs-raw-ID split with unchanged default). Full 6-file suite green. Also verified read-only against the real entry that triggered the report: `keep-names` leaves it byte-identical (all its references are item-name form), and even default mode now preserves the closing quote and backtick.