### PR TITLE
fix: case-insensitive keep-names raw-ID gate; document accepted op:// differential — v1.21.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "author": {
     "name": "LevNas"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.21.1] - 2026-08-16
+
+### Fixed
+- The keep-names raw-ID gate is now case-insensitive, mirroring `OP_REF`: an
+  upper-cased raw 26-char item/vault ID inside an `op://` reference no longer
+  slips through `CCMEMO_REDACT_OP_REF=keep-names` (case parser-differential
+  flagged by security review of the 1.21.0 change).
+
+### Changed
+- The accepted differential vs the shared TS SPEC pattern is documented at
+  the `OP_REF` definition: a NON-canonical reference containing a character
+  outside the URI charset is masked only up to that character, and the
+  surviving tail can only be an item-name fragment — raw IDs are single
+  in-charset segments and are always masked whole; canonical references
+  percent-encode such characters and are unaffected.
+- Docs now name 1Password explicitly for the `op://` bullets: the pattern is
+  scoped to 1Password's secret-reference URI scheme and is inert for
+  knowledge bases that do not use it.
+
 ## [1.21.0] - 2026-08-16
 
 ### Fixed

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -84,7 +84,7 @@ Python 標準ライブラリだけで動き、索引も要りません。
 - **著者**：エントリの `author` フィールドの既定は `@<ユーザー名>` です。Git ホスティングのユーザー名に設定します。
 - **ワークフロー**：`skills/*/SKILL.md` を編集すると、プロジェクト固有の規約（タグの分類、イシューコメントの書式、プランのテンプレート）を足せます。
 - **自動コミット（オプトイン、既定はオフ）**：`CCMEMO_AUTOCOMMIT=1` を設定すると、セーフティネットのフックがセッション終了時（`SessionEnd`）と compaction の前（`PreCompact`）に、`.claude/knowledge/` と `.claude/tasks/` の変更だけをコミットします。`git add -A` は実行せず、push もしません。漏えいしやすい形が差分に含まれる場合は leak-scan ゲートがコミットを止めます（`CCMEMO_AUTOCOMMIT_ON_LEAK=warn` にすると警告つきでコミットします）。これは手動のセッション終了コミットの置き換えではなく補完なので、すでにコミット済みなら何もしません。
-- **redact フックの `op://` の扱い**：エントリの redact フックは既定で `op://` 参照をすべてマスクします。`CCMEMO_REDACT_OP_REF=keep-names` を設定すると、項目名参照（`op://vault/項目名/field`。秘密の実値を含まない）は残し、26 文字の生 ID 形式セグメントを含む参照だけをマスクします。
+- **redact フックの `op://` の扱い**：エントリの redact フックは既定で `op://` 参照（1Password の secret reference URI。1Password を使わないナレッジベースでは不活性）をすべてマスクします。`CCMEMO_REDACT_OP_REF=keep-names` を設定すると、項目名参照（`op://vault/項目名/field`。秘密の実値を含まない）は残し、26 文字の生 ID 形式セグメントを含む参照だけをマスクします。
 - **自動検索の status フィルタ**：毎プロンプトの `UserPromptSubmit` フックは、frontmatter の `status` が `active` のエントリだけを注入します（`status:` 行が無いエントリは active 扱い）。`CCMEMO_SEARCH_STATUS` にカンマ区切りの許可リスト（例：`active,superseded`）を設定すると広げられ、`all` でフィルタを無効化できます。この経路で表に出た非 active エントリには `[status: …, superseded_by: …]` の注記が付くため、現行の知識と取り違えることはありません。
 
 ## Git リポジトリに置く理由

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,7 +109,8 @@ entries before starting work. Patterns and examples:
   manual end-of-session commit, so it is a no-op when you have already
   committed.
 - **Redact hook `op://` handling** — the entry redact hook masks every
-  `op://` reference by default. Set `CCMEMO_REDACT_OP_REF=keep-names` to keep
+  `op://` reference (1Password secret-reference URIs; inert for knowledge
+  bases that do not use 1Password) by default. Set `CCMEMO_REDACT_OP_REF=keep-names` to keep
   item-name references (`op://vault/item-name/field` — no secret value) and
   mask only references containing a raw 26-character item/vault ID segment.
 - **Auto-search status filter** — the per-prompt `UserPromptSubmit` hook only

--- a/hooks/lib/redact.py
+++ b/hooks/lib/redact.py
@@ -53,6 +53,12 @@ SENSITIVE_KEYS = (
 # mangling the surrounding text. Matching only the URI charset and requiring
 # the match to end on an alphanumeric stops it at quotes, brackets, CJK text
 # and trailing punctuation.
+# Accepted differential vs the TS SPEC: a NON-canonical reference containing
+# a char outside the charset (e.g. a raw comma in an item name) is masked
+# only up to that char and the tail survives. The tail can only be an
+# item-name fragment — raw 26-char item/vault IDs are single segments fully
+# inside the charset, so an ID is always masked whole. Canonical references
+# percent-encode such chars (% is in the charset) and are unaffected.
 OP_REF = re.compile(r"\bop://[A-Za-z0-9._~%/-]*[A-Za-z0-9]", re.IGNORECASE)
 JWT = re.compile(r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}")
 PEM = re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----")
@@ -77,7 +83,10 @@ ENTRY_SECRET_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
 # 1Password item/vault IDs are 26-char lowercase alphanumeric strings. Item
 # NAME references (op://vault/item-name/field) carry no secret value, and a
 # host policy may explicitly allow them (CCMEMO_REDACT_OP_REF=keep-names).
-_OP_RAW_ID = re.compile(r"^[a-z0-9]{26}$")
+# IGNORECASE mirrors OP_REF: the reference itself matches case-insensitively,
+# so the raw-ID gate must too — otherwise an upper-cased raw ID would slip
+# through keep-names (case parser-differential).
+_OP_RAW_ID = re.compile(r"^[a-z0-9]{26}$", re.IGNORECASE)
 
 
 def _op_ref_contains_raw_id(ref: str) -> bool:

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -148,6 +148,20 @@ def test_redact_op_ref_keep_names_mode():
     assert hits2 == [("op-ref", 2)], hits2
 
 
+def test_redact_op_ref_keep_names_case_and_noncanonical_tail():
+    # OP_REF matches case-insensitively; the raw-ID gate must too, or an
+    # upper-cased raw ID slips through keep-names (case parser-differential).
+    up = "OP://PERSONAL/ABCDEFGHIJKLMNOPQRSTUVWXYZ/TOKEN"
+    out, hits = redact.redact_secrets_in_text(f"x {up} y", op_ref_mode="keep-names")
+    assert up not in out and hits == [("op-ref", 1)], (out, hits)
+    # Accepted differential vs the TS SPEC (documented at OP_REF): a
+    # non-canonical ref with a raw comma is masked only up to the comma; the
+    # surviving tail can only be an item-name fragment, never a raw ID.
+    odd = "op://Personal/abc,defsegment/field"
+    out2, _ = redact.redact_secrets_in_text(f"x {odd} y")
+    assert f"{PH},defsegment/field" in out2, out2
+
+
 def main() -> int:
     tests = [v for k, v in sorted(globals().items()) if k.startswith("test_")]
     failed = 0


### PR DESCRIPTION
## Background

A background security review of the 1.21.0 redaction change flagged a parser differential in `hooks/lib/redact.py`. Investigation confirmed two items:

1. **Real bug (fixed)**: `OP_REF` matches case-insensitively, but the keep-names raw-ID gate accepted only lowercase segments — an upper-cased raw 26-char item/vault ID inside an `op://` reference slipped through `CCMEMO_REDACT_OP_REF=keep-names` unmasked. The gate now mirrors `OP_REF` with `IGNORECASE`; regression test added.
2. **Accepted differential (now documented)**: vs the shared TS SPEC pattern (`op://\S+`), a NON-canonical reference containing an out-of-charset character (e.g. a raw comma in an item name) is masked only up to that character. The surviving tail can only be an item-name fragment — raw IDs are single in-charset segments and are always masked whole, and canonical references percent-encode such characters. Documented at the `OP_REF` definition with a behaviour-pinning test.

## Also

Docs now name 1Password explicitly for the `op://` bullets — the pattern is scoped to 1Password's secret-reference URI scheme and is inert for knowledge bases that do not use 1Password (it is one vendor-specific pattern alongside JWT/PEM/GitHub-token, not a prerequisite).

## Tests

`test_policy.py` 11/11 (new: upper-case raw ID masked under keep-names; non-canonical tail behaviour pinned). Full 6-file suite green.