### PR TITLE
docs: close three gaps from the 1.19–1.21 release audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ picks up where you left off.
 - **`/plan-task`** — persist multi-step plans and progress across sessions,
   Git-tracked or issue-centric
 - **Link-graph CLI** — `scripts/kb_graph.py` answers structural questions (hubs,
-  neighborhoods, shortest link paths) and lints link integrity; pure stdlib,
-  pre-commit friendly
+  neighborhoods, shortest link paths), lints link integrity, and applies the
+  mechanical writes deterministically (`link-add` back-links, the `supersede`
+  change flow); pure stdlib, pre-commit friendly
 - **Context Guard** — hooks that defend against knowledge loss when the context
   is compacted
 - **Plain Markdown in git** — entries follow the same branch/merge/review workflow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,3 +149,32 @@ export CCMEMO_CONTEXT_GUARD_THRESHOLD_KB=500  # default: 300
 
 Remove or comment out the relevant entry in `hooks/hooks.json`, or delete the
 `hooks/` directory.
+
+## Entry Redaction & Leak Scan
+
+`postwrite_redact_entries.py` runs after every Write/Edit on a knowledge entry
+(`.claude/knowledge/entries/**.md`) and enforces a shared redact/leak-scan SPEC
+deterministically, so recording does not rely on the model remembering to
+sanitize. Hybrid behaviour (chosen 2026-06-21):
+
+- **Unambiguous secret values** — `op://` references (1Password
+  secret-reference URIs), JWTs, PEM private-key headers, GitHub tokens,
+  non-noreply emails — are masked in place with `‹redacted›`.
+- **Leak-prone shapes** — UUIDs, home paths, `${…}`, base64-ish strings,
+  private repo names (`CCMEMO_PRIVATE_REPO_NAMES`) — are reported as warnings
+  only; masking them correctly needs human context (placeholdering), so the
+  hook prompts instead of clobbering.
+
+The pattern set lives in `hooks/lib/redact.py` and mirrors a TypeScript
+counterpart — the two implementations share the SPEC, not the code. One
+deliberate deviation: the `op://` pattern matches only the URI charset and
+must end on an alphanumeric, so it cannot swallow a closing quote, backtick
+or paren adjacent to a reference (CHANGELOG 1.21.0/1.21.1 has the full
+rationale, including the accepted non-canonical-tail differential).
+
+`CCMEMO_REDACT_OP_REF=keep-names` narrows the `op://` masking to references
+containing a raw 26-character item/vault ID segment, keeping item-name
+references, which carry no secret value. Default: every reference is masked.
+The same `redact`/`leak_scan` modules also gate the opt-in auto-commit
+(`CCMEMO_AUTOCOMMIT`): a safety-net commit is blocked while the staged diff
+contains leak-prone shapes.

--- a/docs/usage.ja.md
+++ b/docs/usage.ja.md
@@ -57,6 +57,16 @@ Python 標準ライブラリだけで動き、索引も要りません。
 `lineage` サブコマンドは、任意のエントリから置換（supersede）チェーンをたどり、いま答えを保持しているエントリまで到達します。
 サブコマンドと pre-commit lint は [link-graph.md](link-graph.md)（英語）にあります。
 
+## 変化を記録する（supersede）
+
+知識は変化します。記録スキルは一問で形を選びます — **旧エントリを今後も現行知識として参照してよいか？** Yes なら in-place 編集、または旧を `active` のまま `amends:`/`extends:` の新エントリを追加。No なら supersede します。
+
+```bash
+python3 scripts/kb_graph.py supersede <旧エントリ> <新エントリ> --reason "何が変わったか"
+```
+
+`status: superseded` + `superseded_by:` の frontmatter ペア、本文冒頭の警告バナー、置換側への `amends:` バックリンクを、全検証後に一括適用します。非 active エントリは毎プロンプトの自動検索に出なくなり（下記カスタマイズ参照）、古いヒットは `lineage` で現行エントリへ解決できます。詳細は [link-graph.md](link-graph.md)（英語）。
+
 ## ナレッジをレビューする
 
 `/review-knowledge` は3つのモードでナレッジベースの健全性を保ちます。

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,6 +62,23 @@ pure stdlib, no index needed. The `lineage` subcommand follows the supersede
 chain from any entry to the one that currently holds the answer. Subcommands
 and pre-commit lint: [link-graph.md](link-graph.md).
 
+## Recording change (supersede)
+
+Knowledge changes. The recording skill picks the form with one question — may
+the old entry still be cited as current knowledge afterwards? Yes → edit in
+place, or add an `amends:`/`extends:` entry with the old one staying `active`;
+no → supersede it:
+
+```bash
+python3 scripts/kb_graph.py supersede <old-entry> <new-entry> --reason "what changed"
+```
+
+One validated step applies the `status: superseded` + `superseded_by:`
+frontmatter pair, a body-top warning banner, and an `amends:` back-link in
+the replacement. Non-active entries stop surfacing in the per-prompt
+auto-search (see Customization below), and `lineage` resolves any stale hit
+to the current authority. Details: [link-graph.md](link-graph.md).
+
 ## Reviewing knowledge
 
 `/review-knowledge` keeps the base healthy in three modes:


### PR DESCRIPTION
## Background

A documentation audit after the 1.19.0–1.21.1 releases found the core docs (usage customization bullets, link-graph.md, the skill procedure, distributed CLAUDE.md templates) complete, with three gaps at the entry-point and architecture level.

## Changes

1. **README features** — the Link-graph CLI bullet described only the read/lint side; it now also names the deterministic writers (`link-add` back-links, the `supersede` change flow). The command cheat-block stays query-only by design.
2. **usage en/ja** — new **Recording change (supersede)** section between searching and reviewing: the one-question decision rule (may the old entry still be cited as current?) and the `supersede` helper, kept in sync across both languages.
3. **architecture** — new **Entry Redaction & Leak Scan** section. The redact hook had no architecture documentation at all; the section covers the hybrid mask/warn behaviour (chosen 2026-06-21), the shared-SPEC relationship with the TypeScript counterpart, the deliberate `op://` pattern deviation, and `CCMEMO_REDACT_OP_REF=keep-names`.

Deliberately **not** changed: getting-started (neither new env var involves setup work whose absence silently breaks a feature — the criterion from the earlier hybrid-search gap), and examples.md (a supersede walkthrough is optional).

Docs only — no runtime change, no version bump; the plugin cache picks these up with the next feature release.