### PR TITLE
fix(hooks): mtime-based context-guard suppression — v1.22.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ccmemo",
   "description": "Persist knowledge and plans across Claude Code sessions. Provides /record-knowledge, /plan-task, /review-knowledge, and /recall-knowledge skills.",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "author": {
     "name": "LevNas"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.22.0] - 2026-08-17
+
+### Fixed
+- The context-guard Stop hook's "recorded recently" suppression no longer
+  scans the transcript for the entries-path substring — mere path *mentions*
+  (the per-prompt auto-search injection alone contains entry paths, as do
+  search results and issue bodies) kept the nudge suppressed almost
+  permanently, which was why the hook rarely fired in real sessions.
+  Suppression is now judged by entry-file **mtimes** under
+  `.claude/knowledge/entries/`, which sees every real write path — direct
+  edits, the canonical subagent recording flow (whose Write happens in a
+  separate transcript and was invisible to any transcript scan), and
+  `kb_graph.py` CLI writes — while being immune to mentions.
+
+### Added
+- `CCMEMO_CONTEXT_GUARD_RECENT_WRITE_MIN` (default 45): how many minutes one
+  entry write keeps the nudge quiet.
+- Threshold guidance for bounded context windows in
+  `docs/architecture.md` (Context Guard → Configuration), including the
+  observed transcript-bytes-per-token rule of thumb.
+- Tests: `tests/test_context_guard.py` — threshold gate, `stop_hook_active`
+  loop guard, mtime suppression and window override, and a regression test
+  pinning that path mentions alone no longer suppress.
+
 ## [1.21.1] - 2026-08-16
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,9 +84,14 @@ is automatically appended to the active task's `context-*.md` file. This provide
 incremental context capture that survives compaction. Only fires when an active task
 exists in `.claude/tasks/readme.md`.
 
-**Stage 2 (Stop hook):** When the transcript exceeds 300KB and no knowledge entry has
-been recorded recently, Claude pauses and asks if you want to run `/record-knowledge`.
-Answer "不要" to skip.
+**Stage 2 (Stop hook):** When the transcript exceeds 300KB and no knowledge entry
+has been written recently, the stop is blocked once so the *model* self-assesses:
+it either records (via `/record-knowledge` / session-wrap) or ends the session
+when only routine work happened. "Recorded recently" is judged by entry-file
+mtimes under `.claude/knowledge/entries/` — not by scanning the transcript,
+where mere path *mentions* (the per-prompt auto-search injection alone contains
+entry paths) used to suppress the nudge almost permanently, and where the
+canonical subagent recording flow leaves no Write call at all.
 
 **Stage 3 (PreCompact hook):** Before compaction, a checkpoint is automatically saved
 to `.claude/context-checkpoints/` with modified file paths and user decisions extracted
@@ -139,11 +144,21 @@ compaction occurs — it does not exist until then.
 
 ### Configuration
 
-Set the size threshold for the Stop hook via environment variable:
+Two environment variables tune the Stop hook:
 
 ```bash
-export CCMEMO_CONTEXT_GUARD_THRESHOLD_KB=500  # default: 300
+export CCMEMO_CONTEXT_GUARD_THRESHOLD_KB=500      # default: 300
+export CCMEMO_CONTEXT_GUARD_RECENT_WRITE_MIN=45   # default: 45
 ```
+
+- `…_THRESHOLD_KB` — transcript size at which the nudge starts firing. The
+  default 300KB corresponds very roughly to a few tens of thousands of context
+  tokens; sessions on a 200k-token window that want a single mid-session nudge
+  comfortably before auto-compaction typically raise it (800–1200KB observed
+  to work well — transcript bytes run at roughly 10KB per 1k context tokens,
+  tool-output-heavy sessions higher).
+- `…_RECENT_WRITE_MIN` — how long one entry write keeps the nudge quiet, so a
+  session that just recorded is not immediately re-nudged.
 
 ### Disabling
 

--- a/hooks/stop_context_guard.py
+++ b/hooks/stop_context_guard.py
@@ -17,11 +17,16 @@ turn with no loop, and recording still goes through the explicit skills
 
 Environment:
     CCMEMO_CONTEXT_GUARD_THRESHOLD_KB: Size threshold in KB (default: 300)
+    CCMEMO_CONTEXT_GUARD_RECENT_WRITE_MIN: How many minutes a knowledge-entry
+        write suppresses the nudge (default: 45)
 """
 
 import json
 import os
 import sys
+import time
+
+ENTRIES_DIR = os.path.join(".claude", "knowledge", "entries")
 
 
 def get_threshold_bytes() -> int:
@@ -30,28 +35,36 @@ def get_threshold_bytes() -> int:
     return kb * 1024
 
 
-def has_recent_knowledge_write(transcript_path: str) -> bool:
-    """Check if a knowledge entry was written recently in the transcript.
+def get_recent_write_window_s() -> int:
+    """Return the suppression window after an entry write, in seconds."""
+    minutes = int(os.environ.get("CCMEMO_CONTEXT_GUARD_RECENT_WRITE_MIN", "45"))
+    return minutes * 60
 
-    Scans the last portion of the transcript for Write/Edit tool calls
-    targeting .claude/knowledge/entries/.
+
+def has_recent_knowledge_write() -> bool:
+    """Whether a knowledge entry in THIS project was written recently.
+
+    Checks entry-file mtimes under .claude/knowledge/entries/ (cwd-relative,
+    the directory the session records into). Deliberately NOT a transcript
+    scan: a substring check suppressed on mere path *mentions* (the per-prompt
+    auto-search injection alone contains entry paths, so the guard almost
+    never fired), while an actual-tool-call check would miss the canonical
+    subagent recording flow, whose Write happens in a separate transcript.
+    File mtimes see every write path — direct edits, recording subagents and
+    kb_graph CLI writes alike.
     """
-    try:
-        size = os.path.getsize(transcript_path)
-    except OSError:
+    latest = 0.0
+    for dirpath, _dirnames, filenames in os.walk(ENTRIES_DIR):
+        for fn in filenames:
+            if not fn.endswith(".md") or fn == "CLAUDE.md":
+                continue
+            try:
+                latest = max(latest, os.path.getmtime(os.path.join(dirpath, fn)))
+            except OSError:
+                continue
+    if not latest:
         return False
-
-    # Read last 100KB of the transcript to check for recent writes
-    read_size = min(size, 100 * 1024)
-    try:
-        with open(transcript_path, "r", encoding="utf-8", errors="replace") as f:
-            if size > read_size:
-                f.seek(size - read_size)
-            tail = f.read()
-    except OSError:
-        return False
-
-    return ".claude/knowledge/entries/" in tail
+    return (time.time() - latest) < get_recent_write_window_s()
 
 
 def main() -> None:
@@ -85,7 +98,7 @@ def main() -> None:
         return
 
     # Check if knowledge was already recorded
-    if has_recent_knowledge_write(transcript_path):
+    if has_recent_knowledge_write():
         print("{}")
         return
 

--- a/tests/test_context_guard.py
+++ b/tests/test_context_guard.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Self-tests for hooks/stop_context_guard.py (mtime-based suppression).
+
+Run: python3 tests/test_context_guard.py   (exit 0 = all pass)
+
+Each test builds a throwaway project dir with a synthetic transcript and an
+entries tree, then runs the hook as a subprocess with that cwd — the same way
+the harness invokes it. All fixture content is synthetic.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+HOOK = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "hooks",
+    "stop_context_guard.py",
+)
+
+
+def make_project(base, transcript_kb, entry_age_s=None, transcript_text=None):
+    """Create a project dir + transcript; return (project_dir, transcript_path)."""
+    project = os.path.join(base, "project")
+    os.makedirs(os.path.join(project, ".claude", "knowledge", "entries", "2026"),
+                exist_ok=True)
+    if entry_age_s is not None:
+        entry = os.path.join(project, ".claude", "knowledge", "entries", "2026",
+                             "20260101-000000-alice-topic.md")
+        with open(entry, "w", encoding="utf-8") as f:
+            f.write("---\ntitle: T\n---\n\nbody\n")
+        past = time.time() - entry_age_s
+        os.utime(entry, (past, past))
+    transcript = os.path.join(base, "transcript.jsonl")
+    text = transcript_text or ("x" * 1024)
+    with open(transcript, "w", encoding="utf-8") as f:
+        while f.tell() < transcript_kb * 1024:
+            f.write(text + "\n")
+    return project, transcript
+
+
+def run_hook(project, transcript, stop_hook_active=False, env_extra=None):
+    env = dict(os.environ)
+    env.pop("CCMEMO_CONTEXT_GUARD_THRESHOLD_KB", None)
+    env.pop("CCMEMO_CONTEXT_GUARD_RECENT_WRITE_MIN", None)
+    if env_extra:
+        env.update(env_extra)
+    payload = {"transcript_path": transcript, "stop_hook_active": stop_hook_active}
+    proc = subprocess.run(
+        [sys.executable, HOOK], input=json.dumps(payload),
+        capture_output=True, text=True, cwd=project, env=env, timeout=30,
+    )
+    return json.loads(proc.stdout)
+
+
+FAILURES = []
+
+
+def check(name, cond, detail=""):
+    if cond:
+        print(f"  ok  {name}")
+    else:
+        print(f"FAIL  {name}  {detail}")
+        FAILURES.append(name)
+
+
+def test_below_threshold_allows_stop():
+    with tempfile.TemporaryDirectory() as base:
+        project, transcript = make_project(base, transcript_kb=100)
+        out = run_hook(project, transcript)
+        check("below threshold: allow", out == {}, out)
+
+
+def test_stop_hook_active_allows_stop():
+    with tempfile.TemporaryDirectory() as base:
+        project, transcript = make_project(base, transcript_kb=400)
+        out = run_hook(project, transcript, stop_hook_active=True)
+        check("stop_hook_active: allow", out == {}, out)
+
+
+def test_big_transcript_and_stale_entries_block():
+    with tempfile.TemporaryDirectory() as base:
+        project, transcript = make_project(base, transcript_kb=400,
+                                           entry_age_s=6 * 3600)
+        out = run_hook(project, transcript)
+        check("stale entries: block", out.get("decision") == "block", out)
+        check("stale entries: reason has size", "KB" in out.get("reason", ""), out)
+
+
+def test_no_entries_dir_content_blocks():
+    with tempfile.TemporaryDirectory() as base:
+        project, transcript = make_project(base, transcript_kb=400)
+        out = run_hook(project, transcript)
+        check("no entries yet: block", out.get("decision") == "block", out)
+
+
+def test_fresh_entry_write_suppresses():
+    with tempfile.TemporaryDirectory() as base:
+        project, transcript = make_project(base, transcript_kb=400, entry_age_s=60)
+        out = run_hook(project, transcript)
+        check("fresh entry write: suppress", out == {}, out)
+
+
+def test_path_mentions_in_transcript_do_not_suppress():
+    # Regression: the old substring check was satisfied by mere path mentions
+    # (the per-prompt auto-search injection alone contains entry paths).
+    with tempfile.TemporaryDirectory() as base:
+        mention = ('関連ナレッジ候補: ほげ '
+                   '(.claude/knowledge/entries/2026/01/20260101-000000-a.md)')
+        project, transcript = make_project(base, transcript_kb=400,
+                                           entry_age_s=6 * 3600,
+                                           transcript_text=mention)
+        out = run_hook(project, transcript)
+        check("path mentions alone: still block",
+              out.get("decision") == "block", out)
+
+
+def test_env_overrides():
+    with tempfile.TemporaryDirectory() as base:
+        project, transcript = make_project(base, transcript_kb=400,
+                                           entry_age_s=6 * 3600)
+        out = run_hook(project, transcript,
+                       env_extra={"CCMEMO_CONTEXT_GUARD_THRESHOLD_KB": "1000"})
+        check("raised threshold: allow", out == {}, out)
+        # a 10-minute-old write is outside a 5-minute suppression window
+        project2, transcript2 = make_project(
+            os.path.join(base, "b"), transcript_kb=400, entry_age_s=600)
+        out2 = run_hook(project2, transcript2,
+                        env_extra={"CCMEMO_CONTEXT_GUARD_RECENT_WRITE_MIN": "5"})
+        check("shortened write window: block",
+              out2.get("decision") == "block", out2)
+
+
+def main():
+    for t in sorted(k for k in globals() if k.startswith("test_")):
+        globals()[t]()
+    if FAILURES:
+        print(f"\n{len(FAILURES)} failure(s)")
+        return 1
+    print("\nall tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

The context-guard Stop hook almost never fired in real sessions, and the reason turned out to be its own suppression heuristic: "knowledge recorded recently" was judged by searching the transcript tail (100KB) for the `.claude/knowledge/entries/` substring. Mere path **mentions** satisfy that check — the per-prompt auto-search injection alone contains entry paths on every user turn, as do search results and issue bodies — so the guard was structurally self-suppressed by ccmemo's own injection hook. In a long real-world session it finally fired at ~2870KB (nearly 10× the 300KB threshold) only because a stretch of merge ceremony pushed every mention out of the tail window.

Tightening to an actual-tool-call scan would fail the opposite way: the canonical subagent recording flow performs its Write in a separate transcript, leaving no Write call in the main one — the guard would then nag right after a successful recording.

## Fix

Judge recency by entry-file **mtimes** under `.claude/knowledge/entries/` (cwd-relative, the tree the session records into). Every real write path touches a file there — direct edits, recording subagents, `kb_graph.py` CLI writes — and mentions cannot. Transcript-format independent.

- `CCMEMO_CONTEXT_GUARD_RECENT_WRITE_MIN` (default 45): minutes one write keeps the nudge quiet.
- `docs/architecture.md`: Stage 2 description updated; Configuration now documents both knobs plus threshold guidance for bounded context windows (transcript bytes ≈ 10KB per 1k context tokens as an observed rule of thumb).

## Tests

New `tests/test_context_guard.py`, 9 checks: threshold gate, `stop_hook_active` loop guard, block with stale/no entries, suppression by a fresh write, both env overrides, and a regression test pinning that a transcript full of path mentions alone no longer suppresses. Full 7-file suite green.