### PR TITLE
docs: prerequisites overhaul — dependency tiers, install commands, platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ any of them by name.
 
 That alone makes the four skills available and wires up the
 [Context Guard](docs/architecture.md#context-guard-since-v110) hooks.
+External tools (`python3`, `jq`/`ripgrep`/`mecab`, `uv`) unlock further
+layers and every layer stays silently dormant without them — install
+commands and platform support (Linux verified; macOS expected; Windows
+partial, WSL recommended) are in
+[getting-started → Prerequisites](docs/getting-started.md#prerequisites).
 
 **2. Scaffold the starter config** — a tag registry for knowledge and an index
 for tasks. Easiest is to just ask Claude Code:

--- a/docs/getting-started.ja.md
+++ b/docs/getting-started.ja.md
@@ -14,12 +14,39 @@
 
 ## 前提
 
-- [Claude Code](https://code.claude.com/docs/en/overview) CLI
-- `git`（エントリは Markdown ファイルとしてリポジトリにコミットします）
-- `rg`（[ripgrep](https://github.com/BurntSushi/ripgrep)）と `jq` と [`mecab`](https://taku910.github.io/mecab/): 毎プロンプトで関連エントリを自動提示するフックは、3つすべてが `PATH` にあるときだけ動きます（欠けていると**黙って何もしません**）。`rg` は `/recall-knowledge` の索引なしフォールバックの土台でもあります
-- 任意: `python3`（リンクグラフ CLI 用。オプトイン）
-- 任意: [`uv`](https://docs.astral.sh/uv/)（意味検索用の最短ランナー。オプトインで、`python3` + pip でも代替可。手順5参照）
-- 任意: [ghq](https://github.com/x-motemen/ghq)（後述のクローン配置を自動化）
+始めるのに必須なのは Claude Code と `git` だけです。各機能レイヤーは自分の道具の有無を確認し、無ければ**黙って休眠**します。使いたいレイヤーの分だけインストールしてください。
+
+| レイヤー | 提供するもの | 必要なツール | 無いとき |
+|---|---|---|---|
+| コアスキル | `/record-knowledge`・`/plan-task`・`/review-knowledge` | [Claude Code](https://code.claude.com/docs/en/overview)・`git` | — |
+| 安全網フックとグラフ CLI | 秘密情報の redaction・context guard・自動コミット（オプトイン）・タスクミラー・`kb_graph.py`（lint / `link-add` / `supersede` / `lineage`） | `python3`（3.10+。標準ライブラリのみで pip パッケージ不要） | フックは黙ってスキップ。グラフ CLI は使えない |
+| 毎プロンプトの自動検索 | 「関連ナレッジ候補」の自動注入 | `bash`・`jq`・[ripgrep](https://github.com/BurntSushi/ripgrep)（`rg`）・[`mecab`](https://taku910.github.io/mecab/)＋辞書 | フックは黙って何もしない。`rg` は `/recall-knowledge` の索引なしフォールバックの土台でもある |
+| 意味検索（手順5） | `/recall-knowledge` のベクトル検索 | [`uv`](https://docs.astral.sh/uv/)（最短）または `python3` + pip（`fastembed`・`sqlite-vec`）。初回のみ約 220MB のモデルをローカルに取得 | ripgrep のみの recall にフォールバック |
+
+いずれのレイヤーでも任意: [ghq](https://github.com/x-motemen/ghq)（後述のクローン配置を自動化）。
+
+### ツールのインストール
+
+Ubuntu / Debian（WSL 含む）:
+
+```bash
+sudo apt install python3 jq ripgrep mecab mecab-ipadic-utf8
+curl -LsSf https://astral.sh/uv/install.sh | sh   # 手順5を使う場合のみ
+```
+
+macOS（Homebrew）:
+
+```bash
+brew install python jq ripgrep mecab mecab-ipadic uv
+```
+
+自動検索フックはプロンプトを mecab で形態素解析するため、**辞書パッケージも必要**です（apt は `mecab-ipadic-utf8`、brew は `mecab-ipadic`）。mecab 本体だけでは動きません。
+
+### プラットフォーム対応状況
+
+- **Linux**（WSL2 含む）— 開発・常用プラットフォームで、上記すべてを検証済み。NixOS では意味検索レイヤーに既知の癖（numpy の `libstdc++` 解決）が1つありますが自動対処されます — [hybrid-search.md](hybrid-search.md)（英語）参照
+- **macOS** — 動作する見込み（依存はすべて Homebrew にあり、フックは素の bash/python3）ですが、定常的なテストはしていません。動作報告歓迎
+- **Windows（ネイティブ）** — 部分対応。コアスキルは動きます。python フックは `python3`（`python` ではなく）が `PATH` で解決する場合のみ動作し、自動検索フックは bash スクリプトのため Git Bash が必要です。mecab のネイティブ導入は現実的でないため、自動検索レイヤーは実質 Linux/macOS/WSL 専用です。Windows では **WSL でフルスタックを動かすのが推奨**です
 
 ## 手順1: リポジトリを配置する
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,17 +17,54 @@ recall loop. The condensed version of this page is the README
 
 ## Prerequisites
 
-- [Claude Code](https://code.claude.com/docs/en/overview) CLI
-- `git` — entries are plain Markdown committed to your repositories
-- `rg` ([ripgrep](https://github.com/BurntSushi/ripgrep)), `jq`, and
-  [`mecab`](https://taku910.github.io/mecab/) — the hook that auto-surfaces
-  relevant entries on every prompt needs all three on `PATH` and **silently
-  does nothing** when one is missing; `rg` also backs `/recall-knowledge`'s
-  index-free fallback
-- Optional: `python3` for the link-graph CLI (opt-in)
-- Optional: [`uv`](https://docs.astral.sh/uv/) for semantic search (opt-in;
-  the simplest runner — `python3` + pip works too, see Step 5)
-- Optional: [ghq](https://github.com/x-motemen/ghq) for the clone layout below
+Nothing beyond Claude Code and `git` is *required* to start: every feature
+layer checks for its tools and **silently stays dormant** when they are
+missing. Install only the layers you want.
+
+| Layer | Powers | Tools | When absent |
+|---|---|---|---|
+| Core skills | `/record-knowledge`, `/plan-task`, `/review-knowledge` | [Claude Code](https://code.claude.com/docs/en/overview), `git` | — |
+| Safety hooks & graph CLI | secret redaction, context guard, opt-in auto-commit, tasks mirroring, `kb_graph.py` (lint / `link-add` / `supersede` / `lineage`) | `python3` (3.10+, stdlib only — no pip packages) | hooks skip silently; graph CLI unavailable |
+| Per-prompt auto-search | 関連ナレッジ候補 injected on every prompt | `bash`, `jq`, [ripgrep](https://github.com/BurntSushi/ripgrep) (`rg`), [`mecab`](https://taku910.github.io/mecab/) + a dictionary | hook silently does nothing; `rg` also backs `/recall-knowledge`'s index-free fallback |
+| Semantic search (Step 5) | vector recall in `/recall-knowledge` | [`uv`](https://docs.astral.sh/uv/) (simplest) or `python3` + pip (`fastembed`, `sqlite-vec`); ~220 MB one-time local model download | falls back to ripgrep-only recall |
+
+Optional either way: [ghq](https://github.com/x-motemen/ghq) for the clone
+layout below.
+
+### Installing the tools
+
+Ubuntu / Debian (including WSL):
+
+```bash
+sudo apt install python3 jq ripgrep mecab mecab-ipadic-utf8
+curl -LsSf https://astral.sh/uv/install.sh | sh   # only for Step 5
+```
+
+macOS (Homebrew):
+
+```bash
+brew install python jq ripgrep mecab mecab-ipadic uv
+```
+
+The auto-search hook tokenizes prompts with mecab, so it needs a dictionary
+package too (`mecab-ipadic-utf8` on apt, `mecab-ipadic` on brew) — mecab
+alone on `PATH` is not enough.
+
+### Platform support
+
+- **Linux** (including WSL2) — the development and daily-driver platform;
+  everything above is verified here. NixOS has one known quirk in the
+  semantic-search layer (`libstdc++` resolution for numpy), handled
+  automatically — see [hybrid-search.md](hybrid-search.md).
+- **macOS** — expected to work (every dependency is a Homebrew formula and
+  the hooks are plain bash/python3), but not regularly tested. Reports
+  welcome.
+- **Windows (native)** — partial. Core skills work. The python hooks run
+  only if `python3` (not just `python`) resolves on `PATH`, and the
+  auto-search hook is a bash script, so it needs Git Bash; mecab is
+  impractical to install natively, which makes the auto-search layer
+  effectively Linux/macOS/WSL-only. On Windows, WSL is the recommended way
+  to run the full stack.
 
 ## Step 1 — Lay out your repositories
 


### PR DESCRIPTION
## Problem

The getting-started prerequisites named the tools but assumed the reader could install them: no package-manager commands, no mecab-dictionary note, and no statement of which OSes the stack is verified on. It also understated `python3` as "optional, for the link-graph CLI" — in reality seven of the eight hooks (secret redaction, context guard, opt-in auto-commit, tasks mirror, checkpoints, context writer, md-link check) run on python3, so a machine without it silently loses the safety net.

## Changes

- **getting-started en/ja** — prerequisites rewritten as a four-tier dependency table (core skills / safety hooks & graph CLI / per-prompt auto-search / semantic search) with the per-tier graceful-degradation behaviour stated up front: nothing is required to start, each layer stays silently dormant without its tools.
  - Install commands for Ubuntu/Debian (incl. WSL) and macOS/Homebrew, including the mecab **dictionary** package (`mecab-ipadic-utf8` / `mecab-ipadic`) — mecab alone on PATH is not enough.
  - Honest platform-support section: **Linux (incl. WSL2) verified** (NixOS quirk delegated to hybrid-search.md); **macOS expected to work, not regularly tested**; **native Windows partial** — python hooks need `python3` (not just `python`) on PATH, the auto-search hook is bash (Git Bash), mecab is impractical natively; **WSL recommended** for the full stack on Windows.
- **README quick start** — one pointer to the prerequisites section so the zero-install default and the tool layers are visible from the entry point.

Docs only — no runtime change, no version bump.